### PR TITLE
Fix throwing exception on importing project

### DIFF
--- a/credentials.gradle
+++ b/credentials.gradle
@@ -4,7 +4,8 @@ Properties getPropertiesFile(String fileLocation) {
     File file = new File(fileLocation)
 
     if (!file.canRead()) {
-        throw new GradleException('Could not read properties file: ' + fileLocation)
+        logger.error('Could not read properties file: ' + fileLocation)
+        return new Properties()
     }
 
     props.load(file.newDataInputStream())


### PR DESCRIPTION
#### Problem

When you try to import the project for the first time you'll face an error regarding a properties file not being read. This happens because there's no `database.credentials` file (you need to create it and add content in there).

I know this is intentional but IMO it would be best if we delay this failure and let the person import the project first, and then fail when they try to build it.
#### Solution

Return an empty `Properties` instance and log an error instead of throwing the exception.
##### Test(s) added

Just a config change.
