### PR TITLE
Parametrise API base endpoint for Google Sheet plugin

### DIFF
--- a/reports-stats-google-sheets/.gitignore
+++ b/reports-stats-google-sheets/.gitignore
@@ -4,3 +4,4 @@ build/
 coverage/
 node_modules/
 gapps.config.json
+src/config.json

--- a/reports-stats-google-sheets/README.md
+++ b/reports-stats-google-sheets/README.md
@@ -33,6 +33,8 @@ npm install -g node-google-apps-script
 
 #### Configuration
 
+##### Google Apps Script
+
 For the first time, you need to create a Google Apps Script project:
 
 1. Go to [https://script.google.com](https://script.google.com) and create a new project
@@ -47,6 +49,11 @@ For the first time, you need to create a Google Apps Script project:
    ([detailed instructions here](https://github.com/danthareja/node-google-apps-script#31-an-existing-apps-script-project))
 
 Now you're ready to develop on this project!
+
+##### Local configuration
+
+To configure the plugin, you need to create a `src/config.json` (see [`src/config.sample.json`]
+(src/config.sample.json)) containing an `api` attribute that points to the Web Service.
 
 #### Available tasks
 

--- a/reports-stats-google-sheets/src/config.sample.json
+++ b/reports-stats-google-sheets/src/config.sample.json
@@ -1,0 +1,3 @@
+{
+  "api": "https://your-website.com/api/"
+}

--- a/reports-stats-google-sheets/src/lib/common/reports.js
+++ b/reports-stats-google-sheets/src/lib/common/reports.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var API_BASE = 'https://t6lqw400oe.execute-api.us-east-1.amazonaws.com/api/';
+<!-- inject:api -->
+var API_BASE = 'https://your-website.com/api/';
+<!-- endinject -->
 var API_REPOS = 'repositories';
 var API_STATS_PR = 'stats/pr';
 var API_ORGANISATION_USERS = '/users/org';


### PR DESCRIPTION
#### Problem

The Google Sheet plugin has the base API endpoint hardcoded in JS.
#### Solution

I have added a new gulp task that injects the API from a `config.json` file and updated the documentation accordingly.

The gulp pipeline has been changed to include the new tasks.
