### PR TITLE
Retrieve float user tasks in batch

### DIFF
--- a/float/src/main/java/com/novoda/floatschedule/task/Task.java
+++ b/float/src/main/java/com/novoda/floatschedule/task/Task.java
@@ -10,6 +10,9 @@ public class Task {
     @SerializedName("task_name")
     private String name;
 
+    @SerializedName("people_id")
+    private String personId;
+
     @SerializedName("person_name")
     private String personName;
 
@@ -33,10 +36,11 @@ public class Task {
         this.name = name;
     }
 
-    public Task(String name, String personName, String projectName) {
+    public Task(String name, String projectName, String personName, String personId) {
         this.name = name;
-        this.personName = personName;
         this.projectName = projectName;
+        this.personName = personName;
+        this.personId = personId;
     }
 
     public String getName() {
@@ -45,6 +49,10 @@ public class Task {
 
     public String getProjectName() {
         return projectName;
+    }
+
+    public String getPersonId() {
+        return personId;
     }
 
     public String getPersonName() {

--- a/float/src/main/java/com/novoda/floatschedule/task/TaskServiceClient.java
+++ b/float/src/main/java/com/novoda/floatschedule/task/TaskServiceClient.java
@@ -3,11 +3,10 @@ package com.novoda.floatschedule.task;
 import com.novoda.floatschedule.convert.FloatDateConverter;
 import com.novoda.floatschedule.network.FloatApiService;
 import com.novoda.floatschedule.network.FloatServiceContainer;
-
-import java.util.Date;
-
 import retrofit2.Response;
 import rx.Observable;
+
+import java.util.Date;
 
 public class TaskServiceClient {
 
@@ -23,6 +22,10 @@ public class TaskServiceClient {
     TaskServiceClient(FloatApiService floatApiService, FloatDateConverter floatDateConverter) {
         this.floatApiService = floatApiService;
         this.floatDateConverter = floatDateConverter;
+    }
+
+    public Observable<Task> getTasksForAllPeople(Date startDate, Integer numberOfWeeks) {
+        return getTasks(startDate, numberOfWeeks, null);
     }
 
     public Observable<Task> getTasks(Date startDate, Integer numberOfWeeks, Integer personId) {

--- a/float/src/test/java/com/novoda/floatschedule/TestSubscriberAssert.java
+++ b/float/src/test/java/com/novoda/floatschedule/TestSubscriberAssert.java
@@ -1,0 +1,88 @@
+package com.novoda.floatschedule;
+
+import rx.Observable;
+import rx.functions.Action1;
+import rx.observers.TestSubscriber;
+import rx.schedulers.Schedulers;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+class TestSubscriberAssert<T> {
+
+    private final Observable<T> observable;
+    private TestSubscriber<T> testSubscriber;
+
+    static <T> TestSubscriberAssert<T> assertThatAnObservable(Observable<T> observable) {
+        return new TestSubscriberAssert<>(observable);
+    }
+
+    private TestSubscriberAssert(Observable<T> observable) {
+        this.observable = observable;
+    }
+
+    TestSubscriberAssert<T> hasEmittedValues(TestSubscriberCustomAssert<T> customAssert, T... values) {
+        TestSubscriber<T> testSubscriber = subscribeMaybe(this.observable);
+
+        List<T> actualElements = testSubscriber.getOnNextEvents();
+        List<T> expectedElements = asList(values);
+
+        assertEquals(expectedElements.size(), actualElements.size());
+        for (int i = 0; i < expectedElements.size(); i++) {
+            customAssert.assertThat(expectedElements.get(i), actualElements.get(i));
+        }
+
+        return this;
+    }
+
+    TestSubscriberAssert<T> hasEmittedValues(Action1<T> customAssert) {
+        TestSubscriber<T> testSubscriber = subscribeMaybe(this.observable);
+
+        testSubscriber.getOnNextEvents().forEach(customAssert::call);
+
+        return this;
+    }
+
+    TestSubscriberAssert<T> hasEmittedValues(T... values) {
+        TestSubscriber<T> testSubscriber = subscribeMaybe(this.observable);
+
+        testSubscriber.assertReceivedOnNext(asList(values));
+
+        return this;
+    }
+
+    TestSubscriberAssert<T> hasEmittedNoValues() {
+        TestSubscriber<T> testSubscriber = subscribeMaybe(this.observable);
+
+        testSubscriber.assertNoValues();
+
+        return this;
+    }
+
+    private TestSubscriber<T> subscribeMaybe(Observable<T> observable) {
+        if (this.testSubscriber == null) {
+            this.testSubscriber = TestSubscriber.create();
+            observable
+                    .subscribeOn(Schedulers.immediate())
+                    .subscribe(this.testSubscriber);
+        }
+
+        return this.testSubscriber;
+    }
+
+    TestSubscriberAssert<T> hasThrown(Class<? extends Exception> exceptionClass) {
+        TestSubscriber<T> testSubscriber = subscribeMaybe(this.observable);
+
+        testSubscriber.assertError(exceptionClass);
+
+        return this;
+    }
+
+
+    @FunctionalInterface
+    interface TestSubscriberCustomAssert<T> {
+        void assertThat(T expected, T actual);
+    }
+}


### PR DESCRIPTION
#### Problem

See #18.
#### Solution

I have added a new method to the `FloatServiceClient` that enables the retrieval of multiple user tasks in one batch.
The client now fetches all tasks within the organisation, then filters them by removing tasks of users we don't need.

This has an immediate effect on the `web-dashboard`, decreasing the wait times for our own `web-service` API and the error rate due to Float API limits.
##### Test(s) added

Yes: I have refactored the `FloatServiceClient` tests for better readability.
###### Paired with

Thanks to @jonreeve for the amazing ideas on refactoring tests.
