### PR TITLE
Send timezone from web-dashboard

### DIFF
--- a/web-dashboard/angular-cli-build.js
+++ b/web-dashboard/angular-cli-build.js
@@ -15,7 +15,8 @@ module.exports = function(defaults) {
       'es6-shim/es6-shim.js',
       'reflect-metadata/**/*.+(ts|js|js.map)',
       'rxjs/**/*.+(js|js.map)',
-      '@angular/**/*.+(js|js.map)'
+      '@angular/**/*.+(js|js.map)',
+      'jstz/dist/jstz.js'
     ]
   });
 };

--- a/web-dashboard/config/environment.dev.ts
+++ b/web-dashboard/config/environment.dev.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: false
+  production: false,
+  mockReports: false
 };

--- a/web-dashboard/package.json
+++ b/web-dashboard/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser-dynamic": "2.0.0-rc.5",
     "@angular/router": "3.0.0-rc.1",
     "core-js": "^2.4.0",
+    "jstz": "^1.0.7",
     "reflect-metadata": "0.1.3",
     "rxjs": "5.0.0-beta.6",
     "ts-helpers": "^1.1.1",

--- a/web-dashboard/src/app/app.module.ts
+++ b/web-dashboard/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { ContributorsComponent } from './contributors/contributors.component';
 import { SlackerComponent } from './slacker/slacker.component';
 import { SlackersComponent } from './slackers/slackers.component';
 import { ConfigService } from './config.service';
+import { TimezoneDetectorService } from './timezone-detector.service';
 
 @NgModule({
   imports: [
@@ -29,19 +30,19 @@ import { ConfigService } from './config.service';
     AppComponent,
     PageNotFoundComponent,
     ContributorsVsSlackersDashboardComponent,
-    ContributorComponent,
     ContributorsComponent,
-    SlackerComponent,
-    SlackersComponent
+    SlackersComponent,
+    ContributorComponent,
+    SlackerComponent
   ],
   providers: [
     SystemClock,
     WeekCalculator,
     ConfigService,
     reportsServiceProvider,
-    ReportsClient
+    ReportsClient,
+    TimezoneDetectorService
   ],
-  entryComponents: [AppComponent],
   bootstrap: [AppComponent]
 })
 export class AppModule {

--- a/web-dashboard/src/app/contributors-vs-slackers-dashboard/contributors-vs-slackers-dashboard.component.spec.ts
+++ b/web-dashboard/src/app/contributors-vs-slackers-dashboard/contributors-vs-slackers-dashboard.component.spec.ts
@@ -10,7 +10,7 @@ import { UserStats } from '../reports/user-stats';
 import { CompanyStats } from '../reports/company-stats';
 import { Observable, Scheduler } from 'rxjs';
 import { ReportsMockService } from '../reports/reports-mock.service';
-import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
+import { TimezoneDetectorService } from '../timezone-detector.service';
 
 describe('Component: ContributorsVsSlackersDashboard', () => {
 
@@ -18,6 +18,7 @@ describe('Component: ContributorsVsSlackersDashboard', () => {
   let weekCalculator: WeekCalculator;
   let reportsService: ReportsMockService;
   let reportsServiceClient: ReportsClient;
+  let timezoneDetectorService: TimezoneDetectorService;
 
   let component: ContributorsVsSlackersDashboardComponent;
 
@@ -29,19 +30,27 @@ describe('Component: ContributorsVsSlackersDashboard', () => {
         provide: ReportsService,
         useClass: ReportsMockService
       },
-      ReportsClient]);
+      ReportsClient,
+      TimezoneDetectorService
+    ]);
   });
 
-  beforeEach(inject([SystemClock, WeekCalculator, ReportsService, ReportsClient],
-    (_clock_, _weekCalculator_, _reportsService_, _reportsServiceClient_) => {
+  beforeEach(inject([SystemClock, WeekCalculator, ReportsService, ReportsClient, TimezoneDetectorService],
+    (_clock_, _weekCalculator_, _reportsService_, _reportsServiceClient_, _timezoneDetectorService_) => {
       clock = _clock_;
       weekCalculator = _weekCalculator_;
       reportsService = _reportsService_;
       reportsServiceClient = _reportsServiceClient_;
+      timezoneDetectorService = _timezoneDetectorService_;
     }));
 
   beforeEach(() => {
-    component = new ContributorsVsSlackersDashboardComponent(weekCalculator, clock, reportsServiceClient);
+    component = new ContributorsVsSlackersDashboardComponent(
+      weekCalculator,
+      clock,
+      reportsServiceClient,
+      timezoneDetectorService
+    );
   });
 
   let contributors;
@@ -184,6 +193,7 @@ describe('Component: ContributorsVsSlackersDashboard', () => {
 
       Scheduler.async.flush();
 
+      expect(timezoneDetectorService.getTimezone).toHaveBeenCalled();
       expect(reportsService.getAggregatedStats).toHaveBeenCalled();
     });
 

--- a/web-dashboard/src/app/contributors-vs-slackers-dashboard/contributors-vs-slackers-dashboard.component.ts
+++ b/web-dashboard/src/app/contributors-vs-slackers-dashboard/contributors-vs-slackers-dashboard.component.ts
@@ -6,6 +6,7 @@ import { CompanyStats } from '../reports/company-stats';
 import { UserStats } from '../reports/user-stats';
 import { Subscription, Observable } from 'rxjs';
 import { OnErrorIgnoreOperator } from '../shared/OnErrorIgnoreOperator';
+import { TimezoneDetectorService } from '../timezone-detector.service';
 
 @Component({
   selector: 'contributors-vs-slackers-dashboard',
@@ -23,7 +24,8 @@ export class ContributorsVsSlackersDashboardComponent implements OnInit, OnDestr
 
   constructor(private weekCalculator: WeekCalculator,
               private clock: SystemClock,
-              private reportsServiceClient: ReportsClient) {
+              private reportsServiceClient: ReportsClient,
+              private timezoneDetector: TimezoneDetectorService) {
     // noop
   }
 
@@ -43,7 +45,8 @@ export class ContributorsVsSlackersDashboardComponent implements OnInit, OnDestr
     return this.reportsServiceClient
       .getCompanyStats(
         this.weekCalculator.getLastMonday(),
-        this.clock.getDate()
+        this.clock.getDate(),
+        this.timezoneDetector.getTimezone()
       )
       .lift(new OnErrorIgnoreOperator<CompanyStats>());
   }

--- a/web-dashboard/src/app/environments/environment.ts
+++ b/web-dashboard/src/app/environments/environment.ts
@@ -4,5 +4,6 @@
 // The build system defaults to the dev environment.
 
 export const environment = {
-  production: false
+  production: false,
+  mockReports: false
 };

--- a/web-dashboard/src/app/jstz.d.ts
+++ b/web-dashboard/src/app/jstz.d.ts
@@ -1,0 +1,7 @@
+declare module 'jstz' {
+  export function determine(): Timezone;
+}
+
+declare interface Timezone {
+  name(): string;
+}

--- a/web-dashboard/src/app/reports/reports-client.service.spec.ts
+++ b/web-dashboard/src/app/reports/reports-client.service.spec.ts
@@ -15,6 +15,7 @@ describe('Service: ReportsClient', () => {
   let service: ReportsService;
   let client: ReportsClient;
   const ANY_DATE: Date = new Date();
+  const ANY_TIMEZONE = 'Europe/London';
 
   beforeEach(() => {
     addProviders([
@@ -54,7 +55,7 @@ describe('Service: ReportsClient', () => {
       }
     });
 
-    client.getCompanyStats(ANY_DATE, ANY_DATE)
+    client.getCompanyStats(ANY_DATE, ANY_DATE, ANY_TIMEZONE)
       .subscribe((actual: CompanyStats) => {
         let expected: CompanyStats = new CompanyStats(
           [new UserStats('takecare', jasmine.any(String), 567, 456)],
@@ -79,7 +80,7 @@ describe('Service: ReportsClient', () => {
       }
     });
 
-    client.getCompanyStats(ANY_DATE, ANY_DATE)
+    client.getCompanyStats(ANY_DATE, ANY_DATE, ANY_TIMEZONE)
       .subscribe((actual: CompanyStats) => {
         let expected: UserStats[] = [
           new UserStats('frapontillo', jasmine.any(String), 234, 123),
@@ -104,7 +105,7 @@ describe('Service: ReportsClient', () => {
       }
     });
 
-    client.getCompanyStats(ANY_DATE, ANY_DATE)
+    client.getCompanyStats(ANY_DATE, ANY_DATE, ANY_TIMEZONE)
       .subscribe((actual: CompanyStats) => {
         let expected: UserStats[] = [
           new UserStats('frapontillo', jasmine.any(String), 234, 0),
@@ -133,7 +134,7 @@ describe('Service: ReportsClient', () => {
       }
     });
 
-    client.getCompanyStats(ANY_DATE, ANY_DATE)
+    client.getCompanyStats(ANY_DATE, ANY_DATE, ANY_TIMEZONE)
       .subscribe((actual: CompanyStats) => {
         let expected: CompanyStats = new CompanyStats(
           [new UserStats('alexstyl', 'OddsChecker, Something', jasmine.any(Number), jasmine.any(Number))],
@@ -160,7 +161,7 @@ describe('Service: ReportsClient', () => {
       }
     });
 
-    client.getCompanyStats(ANY_DATE, ANY_DATE)
+    client.getCompanyStats(ANY_DATE, ANY_DATE, ANY_TIMEZONE)
       .subscribe((actual: CompanyStats) => {
         let expected: CompanyStats = new CompanyStats(
           [new UserStats('alexstyl', 'OddsChecker, Something', jasmine.any(Number), jasmine.any(Number))],
@@ -181,7 +182,7 @@ describe('Service: ReportsClient', () => {
       }
     });
 
-    client.getCompanyStats(ANY_DATE, ANY_DATE)
+    client.getCompanyStats(ANY_DATE, ANY_DATE, ANY_TIMEZONE)
       .subscribe((actual: CompanyStats) => {
         let expected: CompanyStats = new CompanyStats(
           [],
@@ -206,7 +207,7 @@ describe('Service: ReportsClient', () => {
       }
     });
 
-    client.getCompanyStats(ANY_DATE, ANY_DATE)
+    client.getCompanyStats(ANY_DATE, ANY_DATE, ANY_TIMEZONE)
       .subscribe((actual: CompanyStats) => {
         let expected: CompanyStats = new CompanyStats(
           [],

--- a/web-dashboard/src/app/reports/reports-client.service.ts
+++ b/web-dashboard/src/app/reports/reports-client.service.ts
@@ -10,10 +10,10 @@ export class ReportsClient {
   constructor(private reportsService: ReportsService) {
   }
 
-  getCompanyStats(from: Date, to: Date): Observable<CompanyStats> {
+  getCompanyStats(from: Date, to: Date, timezone: string): Observable<CompanyStats> {
 
     return this.reportsService
-      .getAggregatedStats(from, to)
+      .getAggregatedStats(from, to, timezone)
       .mergeMap((stats: {usersStats: any}) => {
         return Observable
           .from(Object

--- a/web-dashboard/src/app/reports/reports.service.provider.ts
+++ b/web-dashboard/src/app/reports/reports.service.provider.ts
@@ -5,10 +5,10 @@ import { ReportsMockService } from './reports-mock.service';
 import { ConfigService } from '../config.service';
 
 let reportsServiceFactory = (http: Http, configService: ConfigService): any => {
-  if (environment.production) {
-    return new ReportsService(http, configService);
+  if (environment.mockReports) {
+    return new ReportsMockService();
   }
-  return new ReportsMockService();
+  return new ReportsService(http, configService);
 };
 
 export const reportsServiceProvider = {

--- a/web-dashboard/src/app/reports/reports.service.spec.ts
+++ b/web-dashboard/src/app/reports/reports.service.spec.ts
@@ -10,6 +10,7 @@ import { Observable } from 'rxjs';
 describe('Service: Reports', () => {
 
   const ANY_DATE = new Date();
+  const ANY_TIMEZONE = 'Europe/London';
 
   let mockBackend: MockBackend;
   let configService: ConfigService;
@@ -49,7 +50,7 @@ describe('Service: Reports', () => {
     let response = new Response(new ResponseOptions({body: '{"some": "string", "one": 1}'}));
     mockBackend.connections.subscribe(connection => connection.mockRespond(response));
 
-    reportsService.getAggregatedStats(ANY_DATE, ANY_DATE)
+    reportsService.getAggregatedStats(ANY_DATE, ANY_DATE, ANY_TIMEZONE)
       .subscribe(value => {
         expect(value).toEqual({
           some: 'string',

--- a/web-dashboard/src/app/reports/reports.service.ts
+++ b/web-dashboard/src/app/reports/reports.service.ts
@@ -11,10 +11,11 @@ export class ReportsService {
   constructor(private http: Http, private config: ConfigService) {
   }
 
-  getAggregatedStats(from: Date, to: Date): Observable<{usersStats: any}> {
+  getAggregatedStats(from: Date, to: Date, timezone: string): Observable<{usersStats: any}> {
     let params = new URLSearchParams();
     params.set('from', from.toISOString());
     params.set('to', to.toISOString());
+    params.set('timezone', timezone);
 
     return this.config
       .getApiBase()

--- a/web-dashboard/src/app/timezone-detector.service.spec.ts
+++ b/web-dashboard/src/app/timezone-detector.service.spec.ts
@@ -1,0 +1,16 @@
+/* tslint:disable:no-unused-variable */
+
+import { addProviders, async, inject } from '@angular/core/testing';
+import { TimezoneDetectorService } from './timezone-detector.service';
+
+describe('Service: TimezoneDetector', () => {
+  beforeEach(() => {
+    addProviders([TimezoneDetectorService]);
+  });
+
+  it('should ...',
+    inject([TimezoneDetectorService],
+      (service: TimezoneDetectorService) => {
+        expect(service).toBeTruthy();
+      }));
+});

--- a/web-dashboard/src/app/timezone-detector.service.spec.ts
+++ b/web-dashboard/src/app/timezone-detector.service.spec.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-unused-variable */
 
-import { addProviders, async, inject } from '@angular/core/testing';
+import { addProviders, inject } from '@angular/core/testing';
 import { TimezoneDetectorService } from './timezone-detector.service';
 
 describe('Service: TimezoneDetector', () => {
@@ -8,9 +8,8 @@ describe('Service: TimezoneDetector', () => {
     addProviders([TimezoneDetectorService]);
   });
 
-  it('should ...',
-    inject([TimezoneDetectorService],
-      (service: TimezoneDetectorService) => {
-        expect(service).toBeTruthy();
-      }));
+  it('creates an instance of TimezoneDetector',
+    inject([TimezoneDetectorService], (service: TimezoneDetectorService) => {
+      expect(service).toBeTruthy();
+    }));
 });

--- a/web-dashboard/src/app/timezone-detector.service.ts
+++ b/web-dashboard/src/app/timezone-detector.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+
+/// <reference path="jstz.d.ts" />
+import * as jstz from 'jstz';
+
+@Injectable()
+export class TimezoneDetectorService {
+
+  constructor() {
+  }
+
+  getTimezone(): string {
+    const timezone = jstz.determine();
+    return timezone.name();
+  }
+
+}

--- a/web-dashboard/src/system-config.ts
+++ b/web-dashboard/src/system-config.ts
@@ -9,10 +9,14 @@
  **********************************************************************************************/
 /** Map relative paths to URLs. */
 const map: any = {
+  'jstz': 'jstz/dist/jstz.js'
 };
 
 /** User packages configuration. */
 const packages: any = {
+  'jstz': {
+    format: 'cjs'
+  }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -44,7 +48,7 @@ const barrels: string[] = [
 
 const cliSystemConfigPackages: any = {};
 barrels.forEach((barrelName: string) => {
-  cliSystemConfigPackages[barrelName] = { main: 'index' };
+  cliSystemConfigPackages[barrelName] = {main: 'index'};
 });
 
 /** Type declaration for ambient System. */
@@ -61,4 +65,4 @@ System.config({
 });
 
 // Apply the user's configuration.
-System.config({ map, packages });
+System.config({map, packages});


### PR DESCRIPTION
#### Problem

The web-dashboard doesn't send the timezone information over to the Web service. This means that the Web service can't parse the `from` and `to` dates correctly, since they are sent as UTC.

#### Solution

I have added the `jstz` library that attempts to retrieve the browser timezone based on date offset.

To use the library with Webpack/SystemJS I had to include the relevant mapping in `system-config.ts` and add the glob to `angular-cli-build.js`.

##### Test(s) added

Simple default instantiation test.
