### PR TITLE
PT-256 Use timezone on server

### DIFF
--- a/float/src/main/java/com/novoda/floatschedule/AssignmentServiceClient.java
+++ b/float/src/main/java/com/novoda/floatschedule/AssignmentServiceClient.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 public class AssignmentServiceClient {
@@ -40,7 +41,7 @@ public class AssignmentServiceClient {
     public Observable<String> getGithubUsernamesAssignedToRepositories(List<String> repositoryNames,
                                                                        Date startDate,
                                                                        int numberOfWeeks,
-                                                                       String timezone) {
+                                                                       TimeZone timezone) {
 
         List<String> floatProjectNames = getFloatProjectNamesFrom(repositoryNames);
         return getGithubUsernamesAssignedToProjects(floatProjectNames, startDate, numberOfWeeks, timezone);
@@ -62,7 +63,11 @@ public class AssignmentServiceClient {
         }
     }
 
-    public Observable<String> getGithubUsernamesAssignedToProjects(List<String> floatProjectNames, Date startDate, int numberOfWeeks, String timezone) {
+    public Observable<String> getGithubUsernamesAssignedToProjects(List<String> floatProjectNames,
+                                                                   Date startDate,
+                                                                   int numberOfWeeks,
+                                                                   TimeZone timezone) {
+
         return taskServiceClient.getTasks(startDate, numberOfWeeks, timezone, NO_PERSON_ID)
                 .filter(byProjectNameIn(floatProjectNames))
                 .map(Task::getPersonName)

--- a/float/src/main/java/com/novoda/floatschedule/AssignmentServiceClient.java
+++ b/float/src/main/java/com/novoda/floatschedule/AssignmentServiceClient.java
@@ -4,15 +4,14 @@ import com.novoda.floatschedule.convert.FloatGithubProjectConverter;
 import com.novoda.floatschedule.convert.FloatGithubUserConverter;
 import com.novoda.floatschedule.task.Task;
 import com.novoda.floatschedule.task.TaskServiceClient;
+import rx.Observable;
+import rx.functions.Func1;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import rx.Observable;
-import rx.functions.Func1;
 
 public class AssignmentServiceClient {
 
@@ -38,9 +37,13 @@ public class AssignmentServiceClient {
         this.floatGithubProjectConverter = floatGithubProjectConverter;
     }
 
-    public Observable<String> getGithubUsernamesAssignedToRepositories(List<String> repositoryNames, Date startDate, int numberOfWeeks) {
+    public Observable<String> getGithubUsernamesAssignedToRepositories(List<String> repositoryNames,
+                                                                       Date startDate,
+                                                                       int numberOfWeeks,
+                                                                       String timezone) {
+
         List<String> floatProjectNames = getFloatProjectNamesFrom(repositoryNames);
-        return getGithubUsernamesAssignedToProjects(floatProjectNames, startDate, numberOfWeeks);
+        return getGithubUsernamesAssignedToProjects(floatProjectNames, startDate, numberOfWeeks, timezone);
     }
 
     private List<String> getFloatProjectNamesFrom(List<String> repositoryNames) {
@@ -59,8 +62,8 @@ public class AssignmentServiceClient {
         }
     }
 
-    public Observable<String> getGithubUsernamesAssignedToProjects(List<String> floatProjectNames, Date startDate, int numberOfWeeks) {
-        return taskServiceClient.getTasks(startDate, numberOfWeeks, NO_PERSON_ID)
+    public Observable<String> getGithubUsernamesAssignedToProjects(List<String> floatProjectNames, Date startDate, int numberOfWeeks, String timezone) {
+        return taskServiceClient.getTasks(startDate, numberOfWeeks, timezone, NO_PERSON_ID)
                 .filter(byProjectNameIn(floatProjectNames))
                 .map(Task::getPersonName)
                 .map(toGithubUsernameOrNull())

--- a/float/src/main/java/com/novoda/floatschedule/FloatServiceClient.java
+++ b/float/src/main/java/com/novoda/floatschedule/FloatServiceClient.java
@@ -61,38 +61,38 @@ public class FloatServiceClient {
         this.floatDateConverter = floatDateConverter;
     }
 
-    Observable<String> getRepositoryNamesForGithubUser(String githubUsername, Date startDate, int numberOfWeeks)
+    Observable<String> getRepositoryNamesForGithubUser(String githubUsername, Date startDate, int numberOfWeeks, String timezone)
             throws IOException, NoMatchFoundException {
 
-        return getRepositoryNamesForFloatUser(getFloatUsername(githubUsername), startDate, numberOfWeeks);
+        return getRepositoryNamesForFloatUser(getFloatUsername(githubUsername), startDate, numberOfWeeks, timezone);
     }
 
-    Observable<String> getRepositoryNamesForFloatUser(String floatUsername, Date startDate, int numberOfWeeks) {
-        return getTasksForFloatUser(floatUsername, startDate, numberOfWeeks)
+    Observable<String> getRepositoryNamesForFloatUser(String floatUsername, Date startDate, int numberOfWeeks, String timezone) {
+        return getTasksForFloatUser(floatUsername, startDate, numberOfWeeks, timezone)
                 .map(this::getRepositoriesFor)
                 .collect((Func0<List<String>>) ArrayList::new, List::addAll)
                 .flatMapIterable(UtilityFunctions.identity())
                 .distinct();
     }
 
-    Observable<Task> getTasksForGithubUser(String githubUsername, Date startDate, Integer numberOfWeeks) {
+    Observable<Task> getTasksForGithubUser(String githubUsername, Date startDate, Integer numberOfWeeks, String timezone) {
         String floatUsername;
         try {
             floatUsername = getFloatUsername(githubUsername);
         } catch (IOException e) {
             return Observable.error(e);
         }
-        return getTasksForFloatUser(floatUsername, startDate, numberOfWeeks);
+        return getTasksForFloatUser(floatUsername, startDate, numberOfWeeks, timezone);
     }
 
     private String getFloatUsername(String githubUsername) throws IOException, NoMatchFoundException {
         return floatGithubUserConverter.getFloatUser(githubUsername);
     }
 
-    Observable<Task> getTasksForFloatUser(String floatUsername, Date startDate, Integer numberOfWeeks) {
+    Observable<Task> getTasksForFloatUser(String floatUsername, Date startDate, Integer numberOfWeeks, String timezone) {
         return peopleServiceClient.getPersons()
                 .filter(byFloatUsername(floatUsername))
-                .flatMap(toTasks(startDate, numberOfWeeks))
+                .flatMap(toTasks(startDate, numberOfWeeks, timezone))
                 .filter(excludingHolidays());
     }
 
@@ -100,19 +100,20 @@ public class FloatServiceClient {
         return person -> personHasFloatUsername(person, floatUsername);
     }
 
-    private Func1<Person, Observable<Task>> toTasks(Date startDate, Integer numberOfWeeks) {
-        return person -> taskServiceClient.getTasks(startDate, numberOfWeeks, person.getId());
+    private Func1<Person, Observable<Task>> toTasks(Date startDate, Integer numberOfWeeks, String timezone) {
+        return person -> taskServiceClient.getTasks(startDate, numberOfWeeks, timezone, person.getId());
     }
 
     public HashMap<String, List<UserAssignments>> getGithubUsersAssignmentsInDateRange(List<String> githubUsers,
                                                                                        Date from,
-                                                                                       Date to) {
+                                                                                       Date to,
+                                                                                       String timezone) {
 
         if (listIsNullOrEmpty(githubUsers)) {
             githubUsers = getGithubUsersOrEmpty();
         }
 
-        return getTasksForGithubUsers(githubUsers, from, to)
+        return getTasksForGithubUsers(githubUsers, from, to, timezone)
                 .map(tasksToUserAssignments())
                 .collect(HashMap<String, List<UserAssignments>>::new, putEntryInMap())
                 .toBlocking()
@@ -133,15 +134,17 @@ public class FloatServiceClient {
 
     Observable<Map.Entry<String, List<Task>>> getTasksForGithubUsers(List<String> githubUsernames,
                                                                      Date startDate,
-                                                                     Date endDate) {
+                                                                     Date endDate,
+                                                                     String timezone) {
 
         Integer numberOfWeeks = numberOfWeeksCalculator.getNumberOfWeeksOrNullIn(startDate, endDate);
-        return getTasksForGithubUsers(githubUsernames, startDate, numberOfWeeks);
+        return getTasksForGithubUsers(githubUsernames, startDate, numberOfWeeks, timezone);
     }
 
     private Observable<Map.Entry<String, List<Task>>> getTasksForGithubUsers(List<String> githubUsernames,
                                                                              Date startDate,
-                                                                             Integer numberOfWeeks) {
+                                                                             Integer numberOfWeeks,
+                                                                             String timezone) {
 
         Map<String, String> floatToGithubUsernames;
         try {
@@ -153,7 +156,7 @@ public class FloatServiceClient {
         return peopleServiceClient.getPersons()
                 .filter(byFloatUsernames(floatToGithubUsernames.keySet()))
                 .toList()
-                .flatMap(peopleToGithubUserWithTasksEntry(startDate, numberOfWeeks, floatToGithubUsernames));
+                .flatMap(peopleToGithubUserWithTasksEntry(startDate, numberOfWeeks, timezone, floatToGithubUsernames));
     }
 
     Map<String, String> mapFloatToGithubUsernames(List<String> githubUsernames)
@@ -196,9 +199,13 @@ public class FloatServiceClient {
         return person.getName().equalsIgnoreCase(floatUsername);
     }
 
-    private Func1<List<Person>, Observable<? extends Map.Entry<String, List<Task>>>> peopleToGithubUserWithTasksEntry(Date startDate, Integer numberOfWeeks, Map<String, String> floatToGithubUsernames) {
+    private Func1<List<Person>, Observable<? extends Map.Entry<String, List<Task>>>> peopleToGithubUserWithTasksEntry(Date startDate,
+                                                                                                                      Integer numberOfWeeks,
+                                                                                                                      String timezone,
+                                                                                                                      Map<String, String> floatToGithubUsernames) {
+
         return persons -> taskServiceClient
-                .getTasksForAllPeople(startDate, numberOfWeeks)
+                .getTasksForAllPeople(startDate, numberOfWeeks, timezone)
                 .filter(excludingHolidays())
                 .filter(excludingTaskForNonRequestedPeople(persons))
                 .groupBy(Task::getPersonId)

--- a/float/src/main/java/com/novoda/floatschedule/FloatServiceClient.java
+++ b/float/src/main/java/com/novoda/floatschedule/FloatServiceClient.java
@@ -61,13 +61,13 @@ public class FloatServiceClient {
         this.floatDateConverter = floatDateConverter;
     }
 
-    Observable<String> getRepositoryNamesForGithubUser(String githubUsername, Date startDate, int numberOfWeeks, String timezone)
+    Observable<String> getRepositoryNamesForGithubUser(String githubUsername, Date startDate, int numberOfWeeks, TimeZone timezone)
             throws IOException, NoMatchFoundException {
 
         return getRepositoryNamesForFloatUser(getFloatUsername(githubUsername), startDate, numberOfWeeks, timezone);
     }
 
-    Observable<String> getRepositoryNamesForFloatUser(String floatUsername, Date startDate, int numberOfWeeks, String timezone) {
+    Observable<String> getRepositoryNamesForFloatUser(String floatUsername, Date startDate, int numberOfWeeks, TimeZone timezone) {
         return getTasksForFloatUser(floatUsername, startDate, numberOfWeeks, timezone)
                 .map(this::getRepositoriesFor)
                 .collect((Func0<List<String>>) ArrayList::new, List::addAll)
@@ -75,7 +75,7 @@ public class FloatServiceClient {
                 .distinct();
     }
 
-    Observable<Task> getTasksForGithubUser(String githubUsername, Date startDate, Integer numberOfWeeks, String timezone) {
+    Observable<Task> getTasksForGithubUser(String githubUsername, Date startDate, Integer numberOfWeeks, TimeZone timezone) {
         String floatUsername;
         try {
             floatUsername = getFloatUsername(githubUsername);
@@ -89,7 +89,7 @@ public class FloatServiceClient {
         return floatGithubUserConverter.getFloatUser(githubUsername);
     }
 
-    Observable<Task> getTasksForFloatUser(String floatUsername, Date startDate, Integer numberOfWeeks, String timezone) {
+    Observable<Task> getTasksForFloatUser(String floatUsername, Date startDate, Integer numberOfWeeks, TimeZone timezone) {
         return peopleServiceClient.getPersons()
                 .filter(byFloatUsername(floatUsername))
                 .flatMap(toTasks(startDate, numberOfWeeks, timezone))
@@ -100,14 +100,14 @@ public class FloatServiceClient {
         return person -> personHasFloatUsername(person, floatUsername);
     }
 
-    private Func1<Person, Observable<Task>> toTasks(Date startDate, Integer numberOfWeeks, String timezone) {
+    private Func1<Person, Observable<Task>> toTasks(Date startDate, Integer numberOfWeeks, TimeZone timezone) {
         return person -> taskServiceClient.getTasks(startDate, numberOfWeeks, timezone, person.getId());
     }
 
     public HashMap<String, List<UserAssignments>> getGithubUsersAssignmentsInDateRange(List<String> githubUsers,
                                                                                        Date from,
                                                                                        Date to,
-                                                                                       String timezone) {
+                                                                                       TimeZone timezone) {
 
         if (listIsNullOrEmpty(githubUsers)) {
             githubUsers = getGithubUsersOrEmpty();
@@ -135,7 +135,7 @@ public class FloatServiceClient {
     Observable<Map.Entry<String, List<Task>>> getTasksForGithubUsers(List<String> githubUsernames,
                                                                      Date startDate,
                                                                      Date endDate,
-                                                                     String timezone) {
+                                                                     TimeZone timezone) {
 
         Integer numberOfWeeks = numberOfWeeksCalculator.getNumberOfWeeksOrNullIn(startDate, endDate);
         return getTasksForGithubUsers(githubUsernames, startDate, numberOfWeeks, timezone);
@@ -144,7 +144,7 @@ public class FloatServiceClient {
     private Observable<Map.Entry<String, List<Task>>> getTasksForGithubUsers(List<String> githubUsernames,
                                                                              Date startDate,
                                                                              Integer numberOfWeeks,
-                                                                             String timezone) {
+                                                                             TimeZone timezone) {
 
         Map<String, String> floatToGithubUsernames;
         try {
@@ -201,7 +201,7 @@ public class FloatServiceClient {
 
     private Func1<List<Person>, Observable<? extends Map.Entry<String, List<Task>>>> peopleToGithubUserWithTasksEntry(Date startDate,
                                                                                                                       Integer numberOfWeeks,
-                                                                                                                      String timezone,
+                                                                                                                      TimeZone timezone,
                                                                                                                       Map<String, String> floatToGithubUsernames) {
 
         return persons -> taskServiceClient

--- a/float/src/main/java/com/novoda/floatschedule/convert/FloatDateConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/FloatDateConverter.java
@@ -1,5 +1,7 @@
 package com.novoda.floatschedule.convert;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
@@ -16,12 +18,9 @@ public class FloatDateConverter {
     private static final Date NO_DATE = null;
     private static final String NO_STRING = null;
 
-    public String toFloatDateFormat(Date date, TimeZone timezone) {
+    public String toFloatDateFormat(Date date, @NotNull TimeZone timezone) {
         if (date == null) {
             return NO_STRING;
-        }
-        if (timezone == null) {
-            timezone = TimeZone.getDefault();
         }
         ZoneId zoneId = timezone.toZoneId();
         LocalDateTime localDateTime = LocalDateTime.ofInstant(date.toInstant(), zoneId);

--- a/float/src/main/java/com/novoda/floatschedule/convert/FloatDateConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/FloatDateConverter.java
@@ -16,14 +16,13 @@ public class FloatDateConverter {
     private static final Date NO_DATE = null;
     private static final String NO_STRING = null;
 
-    public String toFloatDateFormat(Date date, String timezoneName) {
+    public String toFloatDateFormat(Date date, TimeZone timezone) {
         if (date == null) {
             return NO_STRING;
         }
-        if (timezoneName == null) {
-            timezoneName = TimeZone.getDefault().getID();
+        if (timezone == null) {
+            timezone = TimeZone.getDefault();
         }
-        TimeZone timezone = TimeZone.getTimeZone(timezoneName);
         ZoneId zoneId = timezone.toZoneId();
         LocalDateTime localDateTime = LocalDateTime.ofInstant(date.toInstant(), zoneId);
         return localDateTime.format(FLOAT_DATE_TIME_FORMATTER);

--- a/float/src/main/java/com/novoda/floatschedule/convert/FloatDateConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/FloatDateConverter.java
@@ -20,6 +20,9 @@ public class FloatDateConverter {
         if (date == null) {
             return NO_STRING;
         }
+        if (timezoneName == null) {
+            timezoneName = TimeZone.getDefault().getID();
+        }
         TimeZone timezone = TimeZone.getTimeZone(timezoneName);
         ZoneId zoneId = timezone.toZoneId();
         LocalDateTime localDateTime = LocalDateTime.ofInstant(date.toInstant(), zoneId);

--- a/float/src/main/java/com/novoda/floatschedule/convert/FloatDateConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/FloatDateConverter.java
@@ -2,19 +2,28 @@ package com.novoda.floatschedule.convert;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.TimeZone;
 
 public class FloatDateConverter {
 
-    private static final SimpleDateFormat FLOAT_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+    private static final String FLOAT_DATE_FORMAT = "yyyy-MM-dd";
+    private static final DateTimeFormatter FLOAT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(FLOAT_DATE_FORMAT);
+    private static final SimpleDateFormat FLOAT_SIMPLE_DATE_FORMATTER = new SimpleDateFormat(FLOAT_DATE_FORMAT);
     private static final Date NO_DATE = null;
     private static final String NO_STRING = null;
 
-    public String toFloatDateFormat(Date date) {
+    public String toFloatDateFormat(Date date, String timezoneName) {
         if (date == null) {
             return NO_STRING;
         }
-        return FLOAT_DATE_FORMAT.format(date);
+        TimeZone timezone = TimeZone.getTimeZone(timezoneName);
+        ZoneId zoneId = timezone.toZoneId();
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(date.toInstant(), zoneId);
+        return localDateTime.format(FLOAT_DATE_TIME_FORMATTER);
     }
 
     public Date fromFloatDateFormatOrNoDate(String date) {
@@ -27,7 +36,7 @@ public class FloatDateConverter {
 
     Date fromFloatDateFormat(String date) throws InvalidFloatDateException {
         try {
-            return FLOAT_DATE_FORMAT.parse(date);
+            return FLOAT_SIMPLE_DATE_FORMATTER.parse(date);
         } catch (ParseException e) {
             throw new InvalidFloatDateException(date, e);
         }

--- a/float/src/main/java/com/novoda/floatschedule/task/TaskServiceClient.java
+++ b/float/src/main/java/com/novoda/floatschedule/task/TaskServiceClient.java
@@ -24,12 +24,12 @@ public class TaskServiceClient {
         this.floatDateConverter = floatDateConverter;
     }
 
-    public Observable<Task> getTasksForAllPeople(Date startDate, Integer numberOfWeeks) {
-        return getTasks(startDate, numberOfWeeks, null);
+    public Observable<Task> getTasksForAllPeople(Date startDate, Integer numberOfWeeks, String timezone) {
+        return getTasks(startDate, numberOfWeeks, timezone, null);
     }
 
-    public Observable<Task> getTasks(Date startDate, Integer numberOfWeeks, Integer personId) {
-        String date = floatDateConverter.toFloatDateFormat(startDate);
+    public Observable<Task> getTasks(Date startDate, Integer numberOfWeeks, String timezone, Integer personId) {
+        String date = floatDateConverter.toFloatDateFormat(startDate, timezone);
         return floatApiService.getTasks(date, numberOfWeeks, personId)
                 .map(Response::body)
                 .map(Assignments::getAssignments)

--- a/float/src/main/java/com/novoda/floatschedule/task/TaskServiceClient.java
+++ b/float/src/main/java/com/novoda/floatschedule/task/TaskServiceClient.java
@@ -7,6 +7,7 @@ import retrofit2.Response;
 import rx.Observable;
 
 import java.util.Date;
+import java.util.TimeZone;
 
 public class TaskServiceClient {
 
@@ -24,11 +25,11 @@ public class TaskServiceClient {
         this.floatDateConverter = floatDateConverter;
     }
 
-    public Observable<Task> getTasksForAllPeople(Date startDate, Integer numberOfWeeks, String timezone) {
+    public Observable<Task> getTasksForAllPeople(Date startDate, Integer numberOfWeeks, TimeZone timezone) {
         return getTasks(startDate, numberOfWeeks, timezone, null);
     }
 
-    public Observable<Task> getTasks(Date startDate, Integer numberOfWeeks, String timezone, Integer personId) {
+    public Observable<Task> getTasks(Date startDate, Integer numberOfWeeks, TimeZone timezone, Integer personId) {
         String date = floatDateConverter.toFloatDateFormat(startDate, timezone);
         return floatApiService.getTasks(date, numberOfWeeks, personId)
                 .map(Response::body)

--- a/float/src/test/java/com/novoda/floatschedule/AssignmentServiceClientTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/AssignmentServiceClientTest.java
@@ -5,6 +5,13 @@ import com.novoda.floatschedule.convert.FloatGithubProjectConverter;
 import com.novoda.floatschedule.convert.FloatGithubUserConverter;
 import com.novoda.floatschedule.task.Task;
 import com.novoda.floatschedule.task.TaskServiceClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import rx.Observable;
+import rx.observers.TestSubscriber;
+import rx.schedulers.Schedulers;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -12,15 +19,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-
-import rx.Observable;
-import rx.observers.TestSubscriber;
-import rx.schedulers.Schedulers;
 
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
@@ -30,6 +28,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class AssignmentServiceClientTest {
 
     private static final Date ANY_START_DATE = Date.from(Instant.now());
+    private static final String ANY_TIMEZONE = "Europe/London";
     private static final Integer ANY_NUMBER_OF_WEEKS = 40;
     private static final Integer NO_PERSON_ID = null;
 
@@ -54,12 +53,12 @@ public class AssignmentServiceClientTest {
     public void setUp() throws Exception {
         initMocks(this);
 
-        when(floatDateConverter.toFloatDateFormat(ANY_START_DATE)).thenReturn("2014-01-01");
+        when(floatDateConverter.toFloatDateFormat(ANY_START_DATE, ANY_TIMEZONE)).thenReturn("2014-01-01");
 
         testSubscriber = new TestSubscriber<>();
 
         List<Task> tasks = Arrays.asList(givenATask("proj1", "persA"), givenATask("proj1", "persD"), givenATask("proj2", "persB"),
-                                         givenATask("proj3", "persC"), givenATask("proj4", "persA"), givenATask("proj5", "persE"));
+                givenATask("proj3", "persC"), givenATask("proj4", "persA"), givenATask("proj5", "persE"));
 
         givenTasks(tasks);
         givenGithubUsersFor(tasks);
@@ -72,7 +71,7 @@ public class AssignmentServiceClientTest {
 
     private void givenTasks(List<Task> tasks) {
         Observable<Task> mockTasksObservable = Observable.from(tasks);
-        when(mockTaskServiceClient.getTasks(any(Date.class), anyInt(), eq(NO_PERSON_ID))).thenReturn(mockTasksObservable);
+        when(mockTaskServiceClient.getTasks(any(Date.class), anyInt(), anyString(), eq(NO_PERSON_ID))).thenReturn(mockTasksObservable);
     }
 
     private Task givenATask(String projectName, String personName) {
@@ -97,7 +96,12 @@ public class AssignmentServiceClientTest {
     @Test
     public void givenTasksAndUsers_whenGettingGithubUsernamesForARepository_thenTheCorrectUsernameIsEmitted() {
 
-        assignmentServiceClient.getGithubUsernamesAssignedToRepositories(Collections.singletonList("repoZ"), ANY_START_DATE, ANY_NUMBER_OF_WEEKS)
+        assignmentServiceClient.getGithubUsernamesAssignedToRepositories(
+                Collections.singletonList("repoZ"),
+                ANY_START_DATE,
+                ANY_NUMBER_OF_WEEKS,
+                ANY_TIMEZONE
+        )
                 .subscribeOn(Schedulers.immediate())
                 .subscribe(testSubscriber);
 
@@ -107,9 +111,12 @@ public class AssignmentServiceClientTest {
     @Test
     public void givenTasksAndUsers_whenGettingGithubUsernamesForRepositories_thenTheCorrectUsernamesAreEmittedWithoutDuplicates() {
 
-        assignmentServiceClient.getGithubUsernamesAssignedToRepositories(Arrays.asList("repoX", "repoZ", "repoK"),
-                                                                         ANY_START_DATE,
-                                                                         ANY_NUMBER_OF_WEEKS)
+        assignmentServiceClient.getGithubUsernamesAssignedToRepositories(
+                Arrays.asList("repoX", "repoZ", "repoK"),
+                ANY_START_DATE,
+                ANY_NUMBER_OF_WEEKS,
+                ANY_TIMEZONE
+        )
                 .subscribeOn(Schedulers.immediate())
                 .subscribe(testSubscriber);
 
@@ -117,9 +124,14 @@ public class AssignmentServiceClientTest {
     }
 
     @Test
-    public void givenTasksAndUsers_whenGettingGithubUsernamesForAProject_thenTheCorrectUsernameIsEmitted()  {
+    public void givenTasksAndUsers_whenGettingGithubUsernamesForAProject_thenTheCorrectUsernameIsEmitted() {
 
-        assignmentServiceClient.getGithubUsernamesAssignedToProjects(Collections.singletonList("proj2"), ANY_START_DATE, ANY_NUMBER_OF_WEEKS)
+        assignmentServiceClient.getGithubUsernamesAssignedToProjects(
+                Collections.singletonList("proj2"),
+                ANY_START_DATE,
+                ANY_NUMBER_OF_WEEKS,
+                ANY_TIMEZONE
+        )
                 .subscribeOn(Schedulers.immediate())
                 .subscribe(testSubscriber);
 
@@ -129,7 +141,12 @@ public class AssignmentServiceClientTest {
     @Test
     public void givenTasksAndUsers_whenGettingGithubUsernamesForProjects_thenTheCorrectUsernamesAreEmittedWithoutDuplicates() {
 
-        assignmentServiceClient.getGithubUsernamesAssignedToProjects(Arrays.asList("proj1", "proj4"), ANY_START_DATE, ANY_NUMBER_OF_WEEKS)
+        assignmentServiceClient.getGithubUsernamesAssignedToProjects(
+                Arrays.asList("proj1", "proj4"),
+                ANY_START_DATE,
+                ANY_NUMBER_OF_WEEKS,
+                ANY_TIMEZONE
+        )
                 .subscribeOn(Schedulers.immediate())
                 .subscribe(testSubscriber);
 
@@ -139,7 +156,12 @@ public class AssignmentServiceClientTest {
     @Test
     public void givenTasksAndUsers_whenGettingGithubUsernamesForANonExistentProject_thenTheNothingIsEmitted() {
 
-        assignmentServiceClient.getGithubUsernamesAssignedToProjects(Collections.singletonList("proj88"), ANY_START_DATE, ANY_NUMBER_OF_WEEKS)
+        assignmentServiceClient.getGithubUsernamesAssignedToProjects(
+                Collections.singletonList("proj88"),
+                ANY_START_DATE,
+                ANY_NUMBER_OF_WEEKS,
+                ANY_TIMEZONE
+        )
                 .subscribeOn(Schedulers.immediate())
                 .subscribe(testSubscriber);
 

--- a/float/src/test/java/com/novoda/floatschedule/AssignmentServiceClientTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/AssignmentServiceClientTest.java
@@ -15,10 +15,7 @@ import rx.schedulers.Schedulers;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
@@ -28,7 +25,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class AssignmentServiceClientTest {
 
     private static final Date ANY_START_DATE = Date.from(Instant.now());
-    private static final String ANY_TIMEZONE = "Europe/London";
+    private static final TimeZone ANY_TIMEZONE = TimeZone.getTimeZone("Europe/London");
     private static final Integer ANY_NUMBER_OF_WEEKS = 40;
     private static final Integer NO_PERSON_ID = null;
 
@@ -71,7 +68,8 @@ public class AssignmentServiceClientTest {
 
     private void givenTasks(List<Task> tasks) {
         Observable<Task> mockTasksObservable = Observable.from(tasks);
-        when(mockTaskServiceClient.getTasks(any(Date.class), anyInt(), anyString(), eq(NO_PERSON_ID))).thenReturn(mockTasksObservable);
+        when(mockTaskServiceClient.getTasks(any(Date.class), anyInt(), any(TimeZone.class), eq(NO_PERSON_ID)))
+                .thenReturn(mockTasksObservable);
     }
 
     private Task givenATask(String projectName, String personName) {

--- a/float/src/test/java/com/novoda/floatschedule/FloatServiceClientTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/FloatServiceClientTest.java
@@ -35,6 +35,7 @@ public class FloatServiceClientTest {
     private static final Date ANY_END_DATE = Date.from(Instant.ofEpochMilli(ANY_START_DATE.getTime()).plus(Duration.ofDays(8)));
     private static final String ANY_FLOAT_START_DATE = "2016-07-27";
     private static final String ANY_FLOAT_END_DATE = "2016-08-04";
+    private static final String ANY_TIMEZONE = "Europe/London";
     private static final int ANY_NUMBER_OF_WEEKS = 42;
 
     private static final String FLOAT_MARIO = "Super Mario";
@@ -123,8 +124,8 @@ public class FloatServiceClientTest {
 
         BDDMockito.given(floatDateConverter.fromFloatDateFormatOrNoDate(ANY_FLOAT_START_DATE)).willReturn(ANY_START_DATE);
         BDDMockito.given(floatDateConverter.fromFloatDateFormatOrNoDate(ANY_FLOAT_END_DATE)).willReturn(ANY_END_DATE);
-        BDDMockito.given(floatDateConverter.toFloatDateFormat(ANY_START_DATE)).willReturn(ANY_FLOAT_START_DATE);
-        BDDMockito.given(floatDateConverter.toFloatDateFormat(ANY_END_DATE)).willReturn(ANY_FLOAT_END_DATE);
+        BDDMockito.given(floatDateConverter.toFloatDateFormat(ANY_START_DATE, ANY_TIMEZONE)).willReturn(ANY_FLOAT_START_DATE);
+        BDDMockito.given(floatDateConverter.toFloatDateFormat(ANY_END_DATE, ANY_TIMEZONE)).willReturn(ANY_FLOAT_END_DATE);
     }
 
     private GivenTaskServiceClient given(TaskServiceClient taskServiceClient) {
@@ -144,7 +145,7 @@ public class FloatServiceClientTest {
         given(mockTaskServiceClient).hasAllTasks();
 
         Observable<String> actual = floatServiceClient
-                .getRepositoryNamesForFloatUser(FLOAT_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS);
+                .getRepositoryNamesForFloatUser(FLOAT_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS, ANY_TIMEZONE);
 
         assertThatAnObservable(actual).hasEmittedValues(GITHUB_ALL_4, FLOAT_PROJECT_NOVODA_TV);
     }
@@ -156,7 +157,7 @@ public class FloatServiceClientTest {
         given(mockTaskServiceClient).hasAllTasks();
 
         Observable<String> actual = floatServiceClient
-                .getRepositoryNamesForGithubUser(GITHUB_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS);
+                .getRepositoryNamesForGithubUser(GITHUB_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS, ANY_TIMEZONE);
 
         assertThatAnObservable(actual).hasEmittedValues(GITHUB_ALL_4, FLOAT_PROJECT_NOVODA_TV);
     }
@@ -166,7 +167,7 @@ public class FloatServiceClientTest {
         given(mockTaskServiceClient).hasNoTasks();
 
         Observable<String> actual = floatServiceClient
-                .getRepositoryNamesForFloatUser(FLOAT_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS);
+                .getRepositoryNamesForFloatUser(FLOAT_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS, ANY_TIMEZONE);
 
         assertThatAnObservable(actual).hasEmittedNoValues();
     }
@@ -176,7 +177,7 @@ public class FloatServiceClientTest {
         given(mockTaskServiceClient).hasTasks(TASK_MARIO_ALL_4, TASK_MARIO_BBQ);
 
         Observable<Task> actual = floatServiceClient
-                .getTasksForFloatUser(FLOAT_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS);
+                .getTasksForFloatUser(FLOAT_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS, ANY_TIMEZONE);
 
         assertThatAnObservable(actual).hasEmittedValues(
                 assertTaskNameIsEqual(),
@@ -191,7 +192,7 @@ public class FloatServiceClientTest {
         given(mockTaskServiceClient).hasAllTasks();
 
         Observable<Task> actual = floatServiceClient
-                .getTasksForFloatUser(FLOAT_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS);
+                .getTasksForFloatUser(FLOAT_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS, ANY_TIMEZONE);
 
         assertThatAnObservable(actual)
                 .hasEmittedValues(assertTaskNameDoesNotContainHoliday());
@@ -210,7 +211,7 @@ public class FloatServiceClientTest {
                 .hasTasksForOnePerson(PERSON_MARIO, TASK_MARIO_ALL_4, TASK_MARIO_BBQ);
 
         Observable<Task> actual = floatServiceClient
-                .getTasksForGithubUser(GITHUB_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS);
+                .getTasksForGithubUser(GITHUB_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS, ANY_TIMEZONE);
 
         assertThatAnObservable(actual).hasEmittedValues(assertTaskNameIsEqual(), TASK_MARIO_ALL_4, TASK_MARIO_BBQ);
     }
@@ -226,7 +227,7 @@ public class FloatServiceClientTest {
         List<String> someGithubUsers = asList(GITHUB_MARIO, GITHUB_PEACH);
 
         Observable<Map.Entry<String, List<Task>>> actual = floatServiceClient
-                .getTasksForGithubUsers(someGithubUsers, ANY_START_DATE, ANY_END_DATE);
+                .getTasksForGithubUsers(someGithubUsers, ANY_START_DATE, ANY_END_DATE, ANY_TIMEZONE);
 
         assertThatAnObservable(actual)
                 .hasEmittedValues(
@@ -246,7 +247,7 @@ public class FloatServiceClientTest {
         given(mockFloatGithubUserConverter).failsLookupForGithubUsername(GITHUB_MARIO);
 
         Observable<Task> actual = floatServiceClient
-                .getTasksForGithubUser(GITHUB_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS);
+                .getTasksForGithubUser(GITHUB_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS, ANY_TIMEZONE);
 
         assertThatAnObservable(actual).hasThrown(IOException.class);
     }
@@ -296,7 +297,8 @@ public class FloatServiceClientTest {
         Map<String, List<UserAssignments>> actual = floatServiceClient.getGithubUsersAssignmentsInDateRange(
                 asList(GITHUB_MARIO, GITHUB_PEACH),
                 ANY_START_DATE,
-                ANY_END_DATE
+                ANY_END_DATE,
+                ANY_TIMEZONE
         );
 
         assertEquals(expected, actual);
@@ -317,7 +319,8 @@ public class FloatServiceClientTest {
         Map<String, List<UserAssignments>> actualMap = floatServiceClient.getGithubUsersAssignmentsInDateRange(
                 emptyGithubUsernames,
                 ANY_START_DATE,
-                ANY_END_DATE
+                ANY_END_DATE,
+                ANY_TIMEZONE
         );
 
         assertAllPersonsInKeySet(actualMap.keySet());
@@ -331,7 +334,8 @@ public class FloatServiceClientTest {
         Map<String, List<UserAssignments>> actualMap = floatServiceClient.getGithubUsersAssignmentsInDateRange(
                 nullGithubUsernames,
                 ANY_START_DATE,
-                ANY_END_DATE
+                ANY_END_DATE,
+                ANY_TIMEZONE
         );
 
         assertAllPersonsInKeySet(actualMap.keySet());
@@ -362,6 +366,7 @@ public class FloatServiceClientTest {
             BDDMockito.given(taskServiceClient.getTasks(
                     any(Date.class),
                     anyInt(),
+                    anyString(),
                     eq(personId))
             ).willReturn(mockTasksObservable);
 
@@ -382,7 +387,8 @@ public class FloatServiceClientTest {
             BDDMockito.given(
                     taskServiceClient.getTasksForAllPeople(
                             any(Date.class),
-                            anyInt()
+                            anyInt(),
+                            anyString()
                     )
             ).willReturn(mockTasksObservable);
 

--- a/float/src/test/java/com/novoda/floatschedule/FloatServiceClientTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/FloatServiceClientTest.java
@@ -35,7 +35,7 @@ public class FloatServiceClientTest {
     private static final Date ANY_END_DATE = Date.from(Instant.ofEpochMilli(ANY_START_DATE.getTime()).plus(Duration.ofDays(8)));
     private static final String ANY_FLOAT_START_DATE = "2016-07-27";
     private static final String ANY_FLOAT_END_DATE = "2016-08-04";
-    private static final String ANY_TIMEZONE = "Europe/London";
+    private static final TimeZone ANY_TIMEZONE = TimeZone.getTimeZone("Europe/London");
     private static final int ANY_NUMBER_OF_WEEKS = 42;
 
     private static final String FLOAT_MARIO = "Super Mario";
@@ -366,7 +366,7 @@ public class FloatServiceClientTest {
             BDDMockito.given(taskServiceClient.getTasks(
                     any(Date.class),
                     anyInt(),
-                    anyString(),
+                    any(TimeZone.class),
                     eq(personId))
             ).willReturn(mockTasksObservable);
 
@@ -388,7 +388,7 @@ public class FloatServiceClientTest {
                     taskServiceClient.getTasksForAllPeople(
                             any(Date.class),
                             anyInt(),
-                            anyString()
+                            any(TimeZone.class)
                     )
             ).willReturn(mockTasksObservable);
 

--- a/float/src/test/java/com/novoda/floatschedule/convert/FloatDateConverterTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/convert/FloatDateConverterTest.java
@@ -22,7 +22,7 @@ public class FloatDateConverterTest {
     public void givenADate_whenConvertingToFloatFormat_thenItConvertsAppropriately() throws Exception {
         Date date = givenADate(2016, Calendar.JULY, 1);
 
-        String actual = dateConverter.toFloatDateFormat(date, "Europe/London");
+        String actual = dateConverter.toFloatDateFormat(date, TimeZone.getTimeZone("Europe/London"));
 
         assertEquals("2016-07-01", actual);
     }
@@ -31,7 +31,7 @@ public class FloatDateConverterTest {
     public void givenNonExistingDateInFebruary_whenConvertingToFloatFormat_thenItShiftsDaysToMarchAndConvertsAppropriately() throws Exception {
         Date date = givenADate(1994, Calendar.FEBRUARY, 30);
 
-        String actual = dateConverter.toFloatDateFormat(date, "Europe/London");
+        String actual = dateConverter.toFloatDateFormat(date, TimeZone.getTimeZone("Europe/London"));
 
         assertEquals("1994-03-02", actual);
     }
@@ -40,7 +40,7 @@ public class FloatDateConverterTest {
     public void givenNullDate_whenConvertingToFloatFormat_thenItReturnsNullString() throws Exception {
         Date aNullDate = null;
 
-        String actual = dateConverter.toFloatDateFormat(aNullDate, "Europe/London");
+        String actual = dateConverter.toFloatDateFormat(aNullDate, TimeZone.getTimeZone("Europe/London"));
 
         assertNull(actual);
     }
@@ -76,7 +76,7 @@ public class FloatDateConverterTest {
     public void givenMidnightInLondonAsUTC_whenConvertingToFloatFormat_thenItReturnsDayAfterMidnight() {
         Date date = givenUTCDateWithHour(2016, Calendar.SEPTEMBER, 1, 23);
 
-        String actual = dateConverter.toFloatDateFormat(date, "Europe/London");
+        String actual = dateConverter.toFloatDateFormat(date, TimeZone.getTimeZone("Europe/London"));
 
         assertEquals("2016-09-02", actual);
     }
@@ -85,7 +85,7 @@ public class FloatDateConverterTest {
     public void givenDateAt22InLondonAsUTC_whenConvertingToFloatFormat_thenItReturnsDayBeforeMidnight() {
         Date date = givenUTCDateWithHour(2016, Calendar.SEPTEMBER, 1, 22);
 
-        String actual = dateConverter.toFloatDateFormat(date, "Europe/London");
+        String actual = dateConverter.toFloatDateFormat(date, TimeZone.getTimeZone("Europe/London"));
 
         assertEquals("2016-09-01", actual);
     }

--- a/float/src/test/java/com/novoda/floatschedule/convert/FloatDateConverterTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/convert/FloatDateConverterTest.java
@@ -6,6 +6,7 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.*;
@@ -21,7 +22,7 @@ public class FloatDateConverterTest {
     public void givenADate_whenConvertingToFloatFormat_thenItConvertsAppropriately() throws Exception {
         Date date = givenADate(2016, Calendar.JULY, 1);
 
-        String actual = dateConverter.toFloatDateFormat(date);
+        String actual = dateConverter.toFloatDateFormat(date, "Europe/London");
 
         assertEquals("2016-07-01", actual);
     }
@@ -30,7 +31,7 @@ public class FloatDateConverterTest {
     public void givenNonExistingDateInFebruary_whenConvertingToFloatFormat_thenItShiftsDaysToMarchAndConvertsAppropriately() throws Exception {
         Date date = givenADate(1994, Calendar.FEBRUARY, 30);
 
-        String actual = dateConverter.toFloatDateFormat(date);
+        String actual = dateConverter.toFloatDateFormat(date, "Europe/London");
 
         assertEquals("1994-03-02", actual);
     }
@@ -39,7 +40,7 @@ public class FloatDateConverterTest {
     public void givenNullDate_whenConvertingToFloatFormat_thenItReturnsNullString() throws Exception {
         Date aNullDate = null;
 
-        String actual = dateConverter.toFloatDateFormat(aNullDate);
+        String actual = dateConverter.toFloatDateFormat(aNullDate, "Europe/London");
 
         assertNull(actual);
     }
@@ -71,10 +72,35 @@ public class FloatDateConverterTest {
         assertNull(actual);
     }
 
+    @Test
+    public void givenMidnightInLondonAsUTC_whenConvertingToFloatFormat_thenItReturnsDayAfterMidnight() {
+        Date date = givenUTCDateWithHour(2016, Calendar.SEPTEMBER, 1, 23);
+
+        String actual = dateConverter.toFloatDateFormat(date, "Europe/London");
+
+        assertEquals("2016-09-02", actual);
+    }
+
+    @Test
+    public void givenDateAt22InLondonAsUTC_whenConvertingToFloatFormat_thenItReturnsDayBeforeMidnight() {
+        Date date = givenUTCDateWithHour(2016, Calendar.SEPTEMBER, 1, 22);
+
+        String actual = dateConverter.toFloatDateFormat(date, "Europe/London");
+
+        assertEquals("2016-09-01", actual);
+    }
+
     private Date givenADate(int year, int month, int day) {
         Calendar calendar = Calendar.getInstance();
         calendar.clear();
         calendar.set(year, month, day);
+        return calendar.getTime();
+    }
+
+    private Date givenUTCDateWithHour(int year, int month, int day, int hour) {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        calendar.clear();
+        calendar.set(year, month, day, hour, 0);
         return calendar.getTime();
     }
 

--- a/float/src/test/java/com/novoda/floatschedule/task/TaskServiceClientTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/task/TaskServiceClientTest.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.TimeZone;
 
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -23,7 +24,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class TaskServiceClientTest {
 
     private static final Date ANY_START_DATE = Date.from(Instant.now());
-    private static final String ANY_TIMEZONE = "Europe/London";
+    private static final TimeZone ANY_TIMEZONE = TimeZone.getTimeZone("Europe/London");
     private static final Integer ANY_NUMBER_OF_WEEKS = 42;
     private static final Integer ANY_PERSON_ID = 23;
 

--- a/float/src/test/java/com/novoda/floatschedule/task/TaskServiceClientTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/task/TaskServiceClientTest.java
@@ -2,20 +2,18 @@ package com.novoda.floatschedule.task;
 
 import com.novoda.floatschedule.convert.FloatDateConverter;
 import com.novoda.floatschedule.network.FloatApiService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import retrofit2.Response;
+import rx.Observable;
+import rx.observers.TestSubscriber;
+import rx.schedulers.Schedulers;
 
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-
-import retrofit2.Response;
-import rx.Observable;
-import rx.observers.TestSubscriber;
-import rx.schedulers.Schedulers;
 
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -25,6 +23,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class TaskServiceClientTest {
 
     private static final Date ANY_START_DATE = Date.from(Instant.now());
+    private static final String ANY_TIMEZONE = "Europe/London";
     private static final Integer ANY_NUMBER_OF_WEEKS = 42;
     private static final Integer ANY_PERSON_ID = 23;
 
@@ -52,7 +51,7 @@ public class TaskServiceClientTest {
 
         testSubscriber = new TestSubscriber<>();
 
-        when(mockFloatDateConverter.toFloatDateFormat(ANY_START_DATE)).thenReturn("2014-09-11");
+        when(mockFloatDateConverter.toFloatDateFormat(ANY_START_DATE, ANY_TIMEZONE)).thenReturn("2014-09-11");
 
         taskServiceClient = new TaskServiceClient(mockFloatApiService, mockFloatDateConverter);
 
@@ -66,7 +65,7 @@ public class TaskServiceClientTest {
     public void givenApiReturnsTasks_whenQueryingForTasks_thenEachSingleTaskIsEmitted() {
         when(mockFloatApiService.getTasks(anyString(), anyInt(), anyInt())).thenReturn(apiObservable);
 
-        taskServiceClient.getTasks(ANY_START_DATE, ANY_NUMBER_OF_WEEKS, ANY_PERSON_ID)
+        taskServiceClient.getTasks(ANY_START_DATE, ANY_NUMBER_OF_WEEKS, ANY_TIMEZONE, ANY_PERSON_ID)
                 .subscribeOn(Schedulers.immediate())
                 .subscribe(testSubscriber);
 

--- a/reports-stats/src/main/java/com/novoda/github/reports/stats/command/AggregateOptions.java
+++ b/reports-stats/src/main/java/com/novoda/github/reports/stats/command/AggregateOptions.java
@@ -10,8 +10,8 @@ public class AggregateOptions extends FloatTaskBasedOptions {
 
     // all parameters are in super class (from, to, users)
 
-    public AggregateOptions(List<String> users, Date from, Date to) {
-        super(users, from, to);
+    public AggregateOptions(List<String> users, Date from, Date to, String timezone) {
+        super(users, from, to, timezone);
     }
 
     public AggregateOptions() {

--- a/reports-stats/src/main/java/com/novoda/github/reports/stats/command/AggregateOptions.java
+++ b/reports-stats/src/main/java/com/novoda/github/reports/stats/command/AggregateOptions.java
@@ -4,13 +4,14 @@ import com.beust.jcommander.Parameters;
 
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 @Parameters(commandDescription = "Retrieve aggregated assigned/external statistics about users contributions")
 public class AggregateOptions extends FloatTaskBasedOptions {
 
     // all parameters are in super class (from, to, users)
 
-    public AggregateOptions(List<String> users, Date from, Date to, String timezone) {
+    public AggregateOptions(List<String> users, Date from, Date to, TimeZone timezone) {
         super(users, from, to, timezone);
     }
 

--- a/reports-stats/src/main/java/com/novoda/github/reports/stats/command/FloatTaskBasedOptions.java
+++ b/reports-stats/src/main/java/com/novoda/github/reports/stats/command/FloatTaskBasedOptions.java
@@ -4,14 +4,17 @@ import com.beust.jcommander.Parameter;
 
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 public abstract class FloatTaskBasedOptions extends RangeOptions {
 
     @Parameter(description = "Users to retrieve data for (leave empty for all)")
     private List<String> users;
-    private String timezone;
 
-    public FloatTaskBasedOptions(List<String> users, Date from, Date to, String timezone) {
+    @Parameter(description = "Timezone of the dates", converter = TimeZoneConverter.class)
+    private TimeZone timezone;
+
+    public FloatTaskBasedOptions(List<String> users, Date from, Date to, TimeZone timezone) {
         super(from, to);
         this.users = users;
     }
@@ -24,7 +27,7 @@ public abstract class FloatTaskBasedOptions extends RangeOptions {
         return users;
     }
 
-    public String getTimezone() {
+    public TimeZone getTimezone() {
         return timezone;
     }
 }

--- a/reports-stats/src/main/java/com/novoda/github/reports/stats/command/FloatTaskBasedOptions.java
+++ b/reports-stats/src/main/java/com/novoda/github/reports/stats/command/FloatTaskBasedOptions.java
@@ -9,8 +9,9 @@ public abstract class FloatTaskBasedOptions extends RangeOptions {
 
     @Parameter(description = "Users to retrieve data for (leave empty for all)")
     private List<String> users;
+    private String timezone;
 
-    public FloatTaskBasedOptions(List<String> users, Date from, Date to) {
+    public FloatTaskBasedOptions(List<String> users, Date from, Date to, String timezone) {
         super(from, to);
         this.users = users;
     }
@@ -23,4 +24,7 @@ public abstract class FloatTaskBasedOptions extends RangeOptions {
         return users;
     }
 
+    public String getTimezone() {
+        return timezone;
+    }
 }

--- a/reports-stats/src/main/java/com/novoda/github/reports/stats/command/OverallOptions.java
+++ b/reports-stats/src/main/java/com/novoda/github/reports/stats/command/OverallOptions.java
@@ -4,13 +4,14 @@ import com.beust.jcommander.Parameters;
 
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 @Parameters(commandDescription = "Retrieve overall statistics about users contributions")
 public class OverallOptions extends FloatTaskBasedOptions {
 
     // all parameters are in super class (from, to, users)
 
-    public OverallOptions(List<String> users, Date from, Date to, String timezone) {
+    public OverallOptions(List<String> users, Date from, Date to, TimeZone timezone) {
         super(users, from, to, timezone);
     }
 

--- a/reports-stats/src/main/java/com/novoda/github/reports/stats/command/OverallOptions.java
+++ b/reports-stats/src/main/java/com/novoda/github/reports/stats/command/OverallOptions.java
@@ -10,8 +10,8 @@ public class OverallOptions extends FloatTaskBasedOptions {
 
     // all parameters are in super class (from, to, users)
 
-    public OverallOptions(List<String> users, Date from, Date to) {
-        super(users, from, to);
+    public OverallOptions(List<String> users, Date from, Date to, String timezone) {
+        super(users, from, to, timezone);
     }
 
     public OverallOptions() {

--- a/reports-stats/src/main/java/com/novoda/github/reports/stats/command/PullRequestOptions.java
+++ b/reports-stats/src/main/java/com/novoda/github/reports/stats/command/PullRequestOptions.java
@@ -14,9 +14,10 @@ public class PullRequestOptions extends FloatTaskBasedOptions {
                               PullRequestOptionsGroupBy groupBy,
                               boolean withAverage,
                               Date from,
-                              Date to) {
+                              Date to,
+                              String timezone) {
 
-        super(organisationUsers, from, to);
+        super(organisationUsers, from, to, timezone);
         this.repositories = repositories;
         this.groupBy = groupBy;
         this.withAverage = withAverage;

--- a/reports-stats/src/main/java/com/novoda/github/reports/stats/command/PullRequestOptions.java
+++ b/reports-stats/src/main/java/com/novoda/github/reports/stats/command/PullRequestOptions.java
@@ -5,6 +5,7 @@ import com.beust.jcommander.Parameters;
 
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 @Parameters(commandDescription = "Retrieve statistics about Pull Requests filtered on date, users, projects and repositories")
 public class PullRequestOptions extends FloatTaskBasedOptions {
@@ -15,7 +16,7 @@ public class PullRequestOptions extends FloatTaskBasedOptions {
                               boolean withAverage,
                               Date from,
                               Date to,
-                              String timezone) {
+                              TimeZone timezone) {
 
         super(organisationUsers, from, to, timezone);
         this.repositories = repositories;

--- a/reports-stats/src/main/java/com/novoda/github/reports/stats/command/TimeZoneConverter.java
+++ b/reports-stats/src/main/java/com/novoda/github/reports/stats/command/TimeZoneConverter.java
@@ -1,0 +1,15 @@
+package com.novoda.github.reports.stats.command;
+
+import com.beust.jcommander.IStringConverter;
+
+import java.util.TimeZone;
+
+public class TimeZoneConverter implements IStringConverter<TimeZone> {
+    @Override
+    public TimeZone convert(String value) {
+        if (value == null) {
+            return TimeZone.getDefault();
+        }
+        return TimeZone.getTimeZone(value);
+    }
+}

--- a/reports-stats/src/main/java/com/novoda/github/reports/stats/handler/FloatTaskBasedCommandHandler.java
+++ b/reports-stats/src/main/java/com/novoda/github/reports/stats/handler/FloatTaskBasedCommandHandler.java
@@ -29,7 +29,8 @@ abstract class FloatTaskBasedCommandHandler<S extends Stats, O extends FloatTask
         Map<String, List<UserAssignments>> usersAssignments = floatServiceClient.getGithubUsersAssignmentsInDateRange(
                 options.getUsers(),
                 options.getFrom(),
-                options.getTo()
+                options.getTo(),
+                options.getTimezone()
         );
 
         try {

--- a/reports-stats/src/test/java/com/novoda/github/reports/stats/handler/PullRequestCommandHandlerTest.java
+++ b/reports-stats/src/test/java/com/novoda/github/reports/stats/handler/PullRequestCommandHandlerTest.java
@@ -29,6 +29,7 @@ public class PullRequestCommandHandlerTest {
     private static final Boolean ANY_WITH_AVERAGE = true;
     private static final Date ANY_FROM = new Date();
     private static final Date ANY_TO = new Date();
+    private static final String ANY_TIMEZONE = "Europe/London";
     private static final List<String> ALL_USERS = Arrays.asList("all", "users", "in", "organisation", "here");
 
     @Mock
@@ -76,7 +77,7 @@ public class PullRequestCommandHandlerTest {
     }
 
     private PullRequestOptions givenPullRequestOptionsWith(List<String> users) {
-        return new PullRequestOptions(ANY_REPOSITORIES, users, ANY_GROUP_BY, ANY_WITH_AVERAGE, ANY_FROM, ANY_TO);
+        return new PullRequestOptions(ANY_REPOSITORIES, users, ANY_GROUP_BY, ANY_WITH_AVERAGE, ANY_FROM, ANY_TO, ANY_TIMEZONE);
     }
 
     private void verifyDataLayerWasCalledWith(List<String> users) throws DataLayerException {

--- a/reports-stats/src/test/java/com/novoda/github/reports/stats/handler/PullRequestCommandHandlerTest.java
+++ b/reports-stats/src/test/java/com/novoda/github/reports/stats/handler/PullRequestCommandHandlerTest.java
@@ -11,10 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -29,7 +26,7 @@ public class PullRequestCommandHandlerTest {
     private static final Boolean ANY_WITH_AVERAGE = true;
     private static final Date ANY_FROM = new Date();
     private static final Date ANY_TO = new Date();
-    private static final String ANY_TIMEZONE = "Europe/London";
+    private static final TimeZone ANY_TIMEZONE = TimeZone.getTimeZone("Europe/London");
     private static final List<String> ALL_USERS = Arrays.asList("all", "users", "in", "organisation", "here");
 
     @Mock

--- a/web-service/src/main/java/com/novoda/github/reports/web/lambda/GetAggregatedStatsAction.java
+++ b/web-service/src/main/java/com/novoda/github/reports/web/lambda/GetAggregatedStatsAction.java
@@ -43,7 +43,8 @@ public class GetAggregatedStatsAction implements RequestStreamHandler {
         Map<String, List<UserAssignments>> usersAssignments = floatServiceClient.getGithubUsersAssignmentsInDateRange(
                 request.users(),
                 request.from(),
-                request.to()
+                request.to(),
+                request.timezone()
         );
 
         try {

--- a/web-service/src/main/java/com/novoda/github/reports/web/lambda/GetAggregatedStatsAction.java
+++ b/web-service/src/main/java/com/novoda/github/reports/web/lambda/GetAggregatedStatsAction.java
@@ -17,12 +17,14 @@ import com.ryanharter.auto.value.gson.AutoValueGsonTypeAdapterFactory;
 import java.io.*;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 public class GetAggregatedStatsAction implements RequestStreamHandler {
 
     private static final String ISO_8601_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
     private static final Gson gson = new GsonBuilder()
             .registerTypeAdapterFactory(new AutoValueGsonTypeAdapterFactory())
+            .registerTypeAdapter(TimeZone.class, new TimeZoneTypeAdapter())
             .setDateFormat(ISO_8601_DATE_TIME_FORMAT)
             .create();
 

--- a/web-service/src/main/java/com/novoda/github/reports/web/lambda/GetAggregatedStatsRequest.java
+++ b/web-service/src/main/java/com/novoda/github/reports/web/lambda/GetAggregatedStatsRequest.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 @AutoValue
 public abstract class GetAggregatedStatsRequest {
@@ -26,7 +27,7 @@ public abstract class GetAggregatedStatsRequest {
     public abstract Date to();
 
     @Nullable
-    public abstract String timezone();
+    public abstract TimeZone timezone();
 
     @Nullable
     public abstract List<String> users();
@@ -38,7 +39,7 @@ public abstract class GetAggregatedStatsRequest {
 
         public abstract Builder to(@Nullable Date to);
 
-        public abstract Builder timezone(@Nullable String timezone);
+        public abstract Builder timezone(@Nullable TimeZone timezone);
 
         public abstract Builder users(@Nullable List<String> users);
 

--- a/web-service/src/main/java/com/novoda/github/reports/web/lambda/GetAggregatedStatsRequest.java
+++ b/web-service/src/main/java/com/novoda/github/reports/web/lambda/GetAggregatedStatsRequest.java
@@ -26,6 +26,9 @@ public abstract class GetAggregatedStatsRequest {
     public abstract Date to();
 
     @Nullable
+    public abstract String timezone();
+
+    @Nullable
     public abstract List<String> users();
 
     @AutoValue.Builder
@@ -34,6 +37,8 @@ public abstract class GetAggregatedStatsRequest {
         public abstract Builder from(@Nullable Date from);
 
         public abstract Builder to(@Nullable Date to);
+
+        public abstract Builder timezone(@Nullable String timezone);
 
         public abstract Builder users(@Nullable List<String> users);
 

--- a/web-service/src/main/java/com/novoda/github/reports/web/lambda/TimeZoneTypeAdapter.java
+++ b/web-service/src/main/java/com/novoda/github/reports/web/lambda/TimeZoneTypeAdapter.java
@@ -1,0 +1,31 @@
+package com.novoda.github.reports.web.lambda;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.TimeZone;
+
+class TimeZoneTypeAdapter extends TypeAdapter<TimeZone> {
+
+    @Override
+    public void write(JsonWriter out, TimeZone value) throws IOException {
+        if (value == null) {
+            out.nullValue();
+            return;
+        }
+        out.value(value.getID());
+    }
+
+    @Override
+    public TimeZone read(JsonReader in) throws IOException {
+        if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return TimeZone.getDefault();
+        }
+        return TimeZone.getTimeZone(in.nextString());
+    }
+
+}


### PR DESCRIPTION
#### Problem

The web-dashboard now sends information about the browser timezone, but the server doesn't use it yet. Therefore converting dates to the float format makes us lose one week worth of tasks (in the context of the dashboard).

#### Solution

Add the timezone information to `FloatDateConverter`, then cascade to all usages.

Changes have been already deployed to Amazon AWS and tested with the latest dashboard.

##### Test(s) added

Yes, for the new behaviour and old behaviour that changed.