### PR TITLE
PT-252 Rotate contributors every 3 seconds

### DIFF
--- a/web-dashboard/config/environment.prod.ts
+++ b/web-dashboard/config/environment.prod.ts
@@ -1,3 +1,0 @@
-export const environment = {
-  production: true
-};

--- a/web-dashboard/src/app/app.module.ts
+++ b/web-dashboard/src/app/app.module.ts
@@ -43,6 +43,7 @@ import { TimezoneDetectorService } from './timezone-detector.service';
     ReportsClient,
     TimezoneDetectorService
   ],
+  entryComponents: [AppComponent],
   bootstrap: [AppComponent]
 })
 export class AppModule {

--- a/web-dashboard/src/app/contributor/_contributor.dimen.scss
+++ b/web-dashboard/src/app/contributor/_contributor.dimen.scss
@@ -1,0 +1,1 @@
+$contributor-margin: 15px;

--- a/web-dashboard/src/app/contributor/contributor.component.scss
+++ b/web-dashboard/src/app/contributor/contributor.component.scss
@@ -1,5 +1,5 @@
-$margin: 15px;
-$doubleMargin: $margin * 2;
+@import "contributor.dimen";
+
 $contributor-padding: 15px;
 $contributor-height: 130px;
 
@@ -23,34 +23,13 @@ $contributor-height: 130px;
   box-shadow: 0 40px 40px -30px rgba(0, 0, 0, 0.6);
 
   padding: 15px;
-  margin: $margin;
+  margin: $contributor-margin 0 $contributor-margin $contributor-margin;
   box-sizing: border-box;
 
   overflow-x: auto;
   overflow-y: hidden;
 
-  // min width
-
-  @media screen and (max-width: 600px) {
-    flex-basis: calc(100% - #{$doubleMargin});
-  }
-
-  @media screen and (min-width: 600px) and (max-width: 900px) {
-    flex-basis: calc(50% - #{$doubleMargin});
-  }
-
-  @media screen and (min-width: 900px) and (max-width: 1200px) {
-    flex-basis: calc(33% - #{$doubleMargin});
-  }
-
-  @media screen and (min-width: 1200px) and (max-width: 1500px) {
-    flex-basis: calc(25% - #{$doubleMargin});
-  }
-
-  @media screen and (min-width: 1500px) {
-    flex-basis: calc(20% - #{$doubleMargin});
-  }
-
+  flex-basis: calc(var(--contributor-size));
 }
 
 img {

--- a/web-dashboard/src/app/contributors-vs-slackers-dashboard/contributors-vs-slackers-dashboard.component.spec.ts
+++ b/web-dashboard/src/app/contributors-vs-slackers-dashboard/contributors-vs-slackers-dashboard.component.spec.ts
@@ -53,14 +53,14 @@ describe('Component: ContributorsVsSlackersDashboard', () => {
     );
   });
 
-  let contributors;
+  let companyStats: CompanyStats;
 
   const newUserStats = (username: string): UserStats => {
     return new UserStats(username, null, null, null);
   };
 
   beforeEach(() => {
-    contributors = [
+    const contributors = [
       newUserStats('banana'),
       newUserStats('joe'),
       newUserStats('trinity'),
@@ -68,69 +68,6 @@ describe('Component: ContributorsVsSlackersDashboard', () => {
       newUserStats('boss'),
       newUserStats('goku')
     ];
-  });
-
-  it('creates an instance', () => {
-    expect(component).toBeTruthy();
-  });
-
-  describe('cloneArray', () => {
-
-    it('clones an array', () => {
-      const array = [1, 2, 3];
-
-      const actualCloned = component.cloneArray(array);
-
-      expect(actualCloned).toEqual(array);
-    });
-
-    it('creates a copy of the input array', () => {
-      const array = [1, 2, 3];
-
-      const actualCloned = component.cloneArray(array);
-
-      expect(actualCloned).not.toBe(array);
-    });
-
-  });
-
-  describe('pickAndRemoveRandomContributor', () => {
-
-    it('returns an element that existed in the input array', () => {
-      const copyOfContributors = contributors.slice(0);
-
-      const oneUserStats = component.pickAndRemoveRandomContributor(copyOfContributors);
-
-      expect(contributors.indexOf(oneUserStats)).toBeGreaterThan(-1);
-    });
-
-    it('modifies the input array be removing the returned element', () => {
-      const oneUserStats = component.pickAndRemoveRandomContributor(contributors);
-
-      expect(contributors.indexOf(oneUserStats)).toBe(-1);
-    });
-
-    it('decreases the size of the input array by 1', () => {
-      component.pickAndRemoveRandomContributor(contributors);
-
-      expect(contributors.length).toBe(5);
-    });
-
-    it('returns undefined if the array has no elements', () => {
-      const actual = component.pickAndRemoveRandomContributor([]);
-
-      expect(actual).toBeUndefined();
-    });
-
-    it('returns undefined if the array is undefined', () => {
-      const actual = component.pickAndRemoveRandomContributor(undefined);
-
-      expect(actual).toBeUndefined();
-    });
-
-  });
-
-  describe('pickRandomContributors', () => {
 
     const slackers = [
       newUserStats('blundell'),
@@ -139,43 +76,11 @@ describe('Component: ContributorsVsSlackersDashboard', () => {
       newUserStats('takecare')
     ];
 
-    let companyStats: CompanyStats;
+    companyStats = new CompanyStats(contributors, slackers);
+  });
 
-    beforeEach(() => {
-      companyStats = new CompanyStats(contributors, slackers);
-    });
-
-    it('does not alter the input company stats', () => {
-      component.pickRandomContributors(companyStats);
-
-      expect(companyStats.contributors.length).toBe(6);
-    });
-
-    it('returns 4 random contributors', () => {
-      const randomContributors = component.pickRandomContributors(companyStats);
-
-      expect(randomContributors.length).toBe(5);
-    });
-
-    it('returns all contributors if they are less than 4', () => {
-      const statsWithFewContributors = new CompanyStats(
-        [newUserStats('contributor-1'), newUserStats('contributor-2')],
-        slackers
-      );
-
-      const randomContributors = component.pickRandomContributors(statsWithFewContributors);
-
-      expect(randomContributors.length).toBe(2);
-    });
-
-    it('returns an empty array if there are no contributors', () => {
-      const statsWithFewContributors = new CompanyStats([], slackers);
-
-      const randomContributors = component.pickRandomContributors(statsWithFewContributors);
-
-      expect(randomContributors).toEqual([]);
-    });
-
+  it('creates an instance', () => {
+    expect(component).toBeTruthy();
   });
 
   describe('ngOnInit', () => {

--- a/web-dashboard/src/app/contributors-vs-slackers-dashboard/contributors-vs-slackers-dashboard.component.ts
+++ b/web-dashboard/src/app/contributors-vs-slackers-dashboard/contributors-vs-slackers-dashboard.component.ts
@@ -15,7 +15,6 @@ import { TimezoneDetectorService } from '../timezone-detector.service';
 })
 export class ContributorsVsSlackersDashboardComponent implements OnInit, OnDestroy {
 
-  static NUMBER_OF_CONTRIBUTORS = 5;
   static REFRESH_RATE_IN_MILLISECONDS = 30 * 1000;
 
   public contributors: Array<UserStats>;

--- a/web-dashboard/src/app/contributors-vs-slackers-dashboard/contributors-vs-slackers-dashboard.component.ts
+++ b/web-dashboard/src/app/contributors-vs-slackers-dashboard/contributors-vs-slackers-dashboard.component.ts
@@ -36,7 +36,7 @@ export class ContributorsVsSlackersDashboardComponent implements OnInit, OnDestr
         return this.getCompanyStats();
       })
       .subscribe((stats: CompanyStats) => {
-        this.contributors = this.pickRandomContributors(stats);
+        this.contributors = stats.contributors;
         this.slackers = stats.slackers;
       });
   }
@@ -55,31 +55,6 @@ export class ContributorsVsSlackersDashboardComponent implements OnInit, OnDestr
     if (!this.subscription.isUnsubscribed) {
       this.subscription.unsubscribe();
     }
-  }
-
-  pickRandomContributors(stats: CompanyStats): Array<UserStats> {
-    const contributors = this.cloneArray(stats.contributors);
-
-    const numberOfContributors = Math.min(contributors.length, ContributorsVsSlackersDashboardComponent.NUMBER_OF_CONTRIBUTORS);
-    const randomContributors: Array<UserStats> = new Array(numberOfContributors);
-
-    for (let index = 0; index < numberOfContributors; index++) {
-      randomContributors[index] = this.pickAndRemoveRandomContributor(contributors);
-    }
-
-    return randomContributors;
-  }
-
-  cloneArray(array: Array<any>) {
-    return array.slice(0);
-  }
-
-  pickAndRemoveRandomContributor(users: Array<UserStats>): UserStats {
-    const usersOrEmpty = users || [];
-    const index = Math.floor(Math.random() * usersOrEmpty.length);
-    const user = usersOrEmpty[index];
-    usersOrEmpty.splice(index, 1);
-    return user;
   }
 
 }

--- a/web-dashboard/src/app/contributors/contributors.component.scss
+++ b/web-dashboard/src/app/contributors/contributors.component.scss
@@ -1,6 +1,38 @@
+@import "./../contributor/contributor.dimen";
+
 :host {
   display: flex;
   flex-direction: row;
+
+  @media screen and (max-width: 600px) {
+    --contributor-qty: 1;
+  }
+
+  @media screen and (min-width: 600px) and (max-width: 900px) {
+    --contributor-qty: 2;
+  }
+
+  @media screen and (min-width: 900px) and (max-width: 1200px) {
+    --contributor-qty: 3;
+  }
+
+  @media screen and (min-width: 1200px) and (max-width: 1500px) {
+    --contributor-qty: 4;
+  }
+
+  @media screen and (min-width: 1500px) {
+    --contributor-qty: 5;
+  }
+
+  // the 4 margins are: peeks for previous and next boxes, margins between previous and next boxes
+  --contributor-size: calc((100% / var(--contributor-qty)) - 15px - (45px / var(--contributor-qty)));
+  --contributor-position: 1;
+
+  position: relative;
+  left: calc(#{$contributor-margin} - (var(--contributor-position) - 1) * (#{$contributor-margin} + var(--contributor-size)));
+  transition-property: left;
+  transition-timing-function: ease-in-out;
+  transition-duration: 0.3s;
 
   .no-contributors {
     flex: 1;

--- a/web-dashboard/src/app/contributors/contributors.component.scss
+++ b/web-dashboard/src/app/contributors/contributors.component.scss
@@ -25,7 +25,7 @@
   }
 
   // the 4 margins are: peeks for previous and next boxes, margins between previous and next boxes
-  --contributor-size: calc((100% / var(--contributor-qty)) - 15px - (45px / var(--contributor-qty)));
+  --contributor-size: calc((100% / var(--contributor-qty)) - #{$contributor-margin} - (#{$contributor-margin} * 3 / var(--contributor-qty)));
   --contributor-position: 1;
 
   position: relative;

--- a/web-dashboard/src/app/contributors/contributors.component.ts
+++ b/web-dashboard/src/app/contributors/contributors.component.ts
@@ -1,16 +1,57 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy, HostBinding, ElementRef } from '@angular/core';
 import { UserStats } from '../reports/user-stats';
+import { Subscription, Observable } from 'rxjs';
 
 @Component({
   selector: 'app-contributors',
   templateUrl: 'contributors.component.html',
   styleUrls: ['contributors.component.scss']
 })
-export class ContributorsComponent {
+export class ContributorsComponent implements OnInit, OnDestroy {
+
+  static ROTATE_RATE_IN_MILLISECONDS = 3 * 1000;
+
+  private CONTRIBUTOR_POSITION = '--contributor-position';
+  private CONTRIBUTOR_QTY = '--contributor-qty';
+
+  animation: Subscription;
+  position: number;
+  element;
 
   @Input() contributors: Array<UserStats>;
 
-  constructor() {
+  constructor(element: ElementRef) {
+    this.element = element;
+    this.position = 1;
+  }
+
+  ngOnInit(): void {
+    this.animation = Observable
+      .timer(ContributorsComponent.ROTATE_RATE_IN_MILLISECONDS, ContributorsComponent.ROTATE_RATE_IN_MILLISECONDS)
+      .subscribe(time => {
+        const visibleContributorQuantity = this.getVisibleContributorQuantity();
+        console.log(visibleContributorQuantity);
+        if (this.contributors.length - this.position >= visibleContributorQuantity) {
+          this.position += 1;
+        } else {
+          this.position = 1;
+        }
+        this.setContributorPosition(this.position);
+      });
+  }
+
+  private getVisibleContributorQuantity(): number {
+    return parseInt(window.getComputedStyle(this.element.nativeElement, null).getPropertyValue(this.CONTRIBUTOR_QTY));
+  }
+
+  private setContributorPosition(position: number) {
+    this.element.nativeElement.style.setProperty(this.CONTRIBUTOR_POSITION, position);
+  }
+
+  ngOnDestroy(): void {
+    if (!this.animation.isUnsubscribed) {
+      this.animation.unsubscribe();
+    }
   }
 
 }

--- a/web-dashboard/src/app/contributors/contributors.component.ts
+++ b/web-dashboard/src/app/contributors/contributors.component.ts
@@ -28,16 +28,19 @@ export class ContributorsComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.animation = Observable
       .timer(ContributorsComponent.ROTATE_RATE_IN_MILLISECONDS, ContributorsComponent.ROTATE_RATE_IN_MILLISECONDS)
-      .subscribe(time => {
-        const visibleContributorQuantity = this.getVisibleContributorQuantity();
-        console.log(visibleContributorQuantity);
-        if (this.contributors.length - this.position >= visibleContributorQuantity) {
-          this.position += 1;
-        } else {
-          this.position = 1;
-        }
-        this.setContributorPosition(this.position);
+      .subscribe(() => {
+        this.slideToNextPosition();
       });
+  }
+
+  private slideToNextPosition() {
+    const visibleContributorQuantity = this.getVisibleContributorQuantity();
+    if (this.contributors.length - this.position >= visibleContributorQuantity) {
+      this.position += 1;
+    } else {
+      this.position = 1;
+    }
+    this.setContributorPosition(this.position);
   }
 
   private getVisibleContributorQuantity(): number {

--- a/web-dashboard/src/app/contributors/contributors.component.ts
+++ b/web-dashboard/src/app/contributors/contributors.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnDestroy, HostBinding, ElementRef } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy, ElementRef } from '@angular/core';
 import { UserStats } from '../reports/user-stats';
 import { Subscription, Observable } from 'rxjs';
 
@@ -41,7 +41,7 @@ export class ContributorsComponent implements OnInit, OnDestroy {
   }
 
   private getVisibleContributorQuantity(): number {
-    return parseInt(window.getComputedStyle(this.element.nativeElement, null).getPropertyValue(this.CONTRIBUTOR_QTY));
+    return parseInt(window.getComputedStyle(this.element.nativeElement, null).getPropertyValue(this.CONTRIBUTOR_QTY), 10);
   }
 
   private setContributorPosition(position: number) {

--- a/web-dashboard/src/app/environments/environment.dev.ts
+++ b/web-dashboard/src/app/environments/environment.dev.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: false
+  production: false,
+  mockReports: false
 };

--- a/web-dashboard/src/app/environments/environment.mock.ts
+++ b/web-dashboard/src/app/environments/environment.mock.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  mockReports: false
+  mockReports: true
 };

--- a/web-dashboard/src/app/environments/environment.prod.ts
+++ b/web-dashboard/src/app/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  mockReports: false
 };


### PR DESCRIPTION
#### Problem

Viewing the dashboard does not enforce the idea that the shown contributors are only a subset of all existing ones. Randomly picking contributors when reloading the data isn't a good way to enforce visibility.

#### Solution

I have implemented a CSS-only animation that slides the `left` property of the main container every 3 seconds, so that all contributors are shown. When the latest contributor is shown, the following "slide" takes the container back to the first position.

**NOTE**: due to a bug in Angular 2, some of the slide behaviour is tightly coupled to the view (see https://github.com/angular/angular/issues/9343). As soon as the issue is resolved, it will be a good idea to move to `@HostBinding` and leverage the power of Angular 2 bindings.

##### Screenshots

![gif](https://cloud.githubusercontent.com/assets/1140238/18253628/3a72eca4-738e-11e6-9925-171ab4c7258e.gif)

##### Test(s) added

No, since unit testing isn't possible due to https://github.com/angular/angular/issues/9343.