### PR TITLE
Request GSheets data

### DIFF
--- a/sheets/src/main/java/com/novoda/github/reports/sheets/Main.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/Main.java
@@ -10,7 +10,7 @@ public class Main {
 
         SheetsServiceClient sheetsServiceClient = SheetsServiceClient.newInstance();
         sheetsServiceClient.getDocument()
-                .doOnNext(content -> System.out.println(content))
+                .doOnNext(System.out::println)
                 .subscribeOn(Schedulers.immediate())
                 .subscribe();
 

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/Main.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/Main.java
@@ -1,0 +1,19 @@
+package com.novoda.github.reports.sheets;
+
+import com.novoda.github.reports.sheets.network.SheetsServiceClient;
+
+import rx.schedulers.Schedulers;
+
+public class Main {
+
+    public static void main(String[] args) {
+
+        SheetsServiceClient sheetsServiceClient = SheetsServiceClient.newInstance();
+        sheetsServiceClient.getDocument()
+                .doOnNext(content -> System.out.println(content))
+                .subscribeOn(Schedulers.immediate())
+                .subscribe();
+
+    }
+
+}

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/Main.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/Main.java
@@ -9,7 +9,7 @@ public class Main {
     public static void main(String[] args) {
 
         SheetsServiceClient sheetsServiceClient = SheetsServiceClient.newInstance();
-        sheetsServiceClient.getDocument()
+        sheetsServiceClient.getEntries()
                 .doOnNext(System.out::println)
                 .subscribeOn(Schedulers.immediate())
                 .subscribe();

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsApiService.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsApiService.java
@@ -1,0 +1,21 @@
+package com.novoda.github.reports.sheets.network;
+
+import com.novoda.github.reports.sheets.sheet.Sheet;
+
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import rx.Observable;
+
+public interface SheetsApiService {
+
+
+    //https://spreadsheets.google.com/feeds/list/1rMeGnlugO312to0loBwN3x0QTvAxoHwv4Pe_SYXR1YE/1/public/basic?alt=json
+
+    @GET("{documentId}/1/public/basic?alt=json")
+    Observable<Response<Sheet>> getDocument(@Path("documentId") String documentId);
+
+    @GET("{documentId}/1/public/basic?alt=json")
+    Call<String> debugGetDocument(@Path("documentId") String documentId);
+}

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsApiService.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsApiService.java
@@ -2,7 +2,6 @@ package com.novoda.github.reports.sheets.network;
 
 import com.novoda.github.reports.sheets.sheet.Sheet;
 
-import retrofit2.Call;
 import retrofit2.Response;
 import retrofit2.http.GET;
 import retrofit2.http.Path;
@@ -10,12 +9,7 @@ import rx.Observable;
 
 public interface SheetsApiService {
 
-
-    //https://spreadsheets.google.com/feeds/list/1rMeGnlugO312to0loBwN3x0QTvAxoHwv4Pe_SYXR1YE/1/public/basic?alt=json
-
     @GET("{documentId}/1/public/basic?alt=json")
     Observable<Response<Sheet>> getDocument(@Path("documentId") String documentId);
 
-    @GET("{documentId}/1/public/basic?alt=json")
-    Call<String> debugGetDocument(@Path("documentId") String documentId);
 }

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
@@ -19,7 +19,7 @@ public class SheetsServiceClient {
         return new SheetsServiceClient(apiService);
     }
 
-    private SheetsServiceClient(SheetsApiService apiService) {
+    SheetsServiceClient(SheetsApiService apiService) {
         this.apiService = apiService;
     }
 

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
@@ -2,8 +2,7 @@ package com.novoda.github.reports.sheets.network;
 
 import com.novoda.github.reports.sheets.sheet.Sheet;
 
-import java.io.IOException;
-
+import retrofit2.Response;
 import rx.Observable;
 
 public class SheetsServiceClient {
@@ -26,18 +25,7 @@ public class SheetsServiceClient {
 
     public Observable<Sheet> getDocument() {
         return apiService.getDocument(DOCUMENT_ID)
-                .map(stringResponse -> stringResponse.body());
-    }
-
-    public String debugGetDocument() {
-
-        try {
-            return apiService.debugGetDocument(DOCUMENT_ID).execute().body();
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
-
+                .map(Response::body);
     }
 
 }

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
@@ -22,8 +22,6 @@ public class SheetsServiceClient {
         this.apiService = apiService;
     }
 
-    // TODO should return obs of map<string,string>, or map.entry<string,string>, or something else?
-
     public Observable<Sheet> getDocument() {
         return apiService.getDocument(DOCUMENT_ID)
                 .map(Response::body);

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
@@ -1,0 +1,43 @@
+package com.novoda.github.reports.sheets.network;
+
+import com.novoda.github.reports.sheets.sheet.Sheet;
+
+import java.io.IOException;
+
+import rx.Observable;
+
+public class SheetsServiceClient {
+
+    // TODO extract to .json and read as prop
+    private static final String DOCUMENT_ID = "1rMeGnlugO312to0loBwN3x0QTvAxoHwv4Pe_SYXR1YE";
+
+    private final SheetsApiService apiService;
+
+    public static SheetsServiceClient newInstance() {
+        SheetsApiService apiService = SheetsServiceContainer.getSheetsService();
+        return new SheetsServiceClient(apiService);
+    }
+
+    private SheetsServiceClient(SheetsApiService apiService) {
+        this.apiService = apiService;
+    }
+
+    // TODO should return obs of map<string,string>, or map.entry<string,string>, or something else?
+
+    public Observable<Sheet> getDocument() {
+        return apiService.getDocument(DOCUMENT_ID)
+                .map(stringResponse -> stringResponse.body());
+    }
+
+    public String debugGetDocument() {
+
+        try {
+            return apiService.debugGetDocument(DOCUMENT_ID).execute().body();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+
+    }
+
+}

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
@@ -5,6 +5,7 @@ import com.novoda.github.reports.sheets.sheet.Sheet;
 
 import retrofit2.Response;
 import rx.Observable;
+import rx.functions.Func1;
 
 public class SheetsServiceClient {
 
@@ -29,7 +30,11 @@ public class SheetsServiceClient {
 
     public Observable<Entry> getEntries() {
          return apiService.getDocument(DOCUMENT_ID)
-                 .flatMap(sheetResponse -> Observable.from(sheetResponse.body().getFeed().getEntries()));
+                 .flatMap(toEntries());
+    }
+
+    private Func1<Response<Sheet>, Observable<? extends Entry>> toEntries() {
+        return sheetResponse -> Observable.from(sheetResponse.body().getFeed().getEntries());
     }
 
 }

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
@@ -1,5 +1,6 @@
 package com.novoda.github.reports.sheets.network;
 
+import com.novoda.github.reports.sheets.sheet.Entry;
 import com.novoda.github.reports.sheets.sheet.Sheet;
 
 import retrofit2.Response;
@@ -26,6 +27,11 @@ public class SheetsServiceClient {
     public Observable<Sheet> getDocument() {
         return apiService.getDocument(DOCUMENT_ID)
                 .map(Response::body);
+    }
+
+    public Observable<Entry> getEntries() {
+         return apiService.getDocument(DOCUMENT_ID)
+                 .flatMap(sheetResponse -> Observable.from(sheetResponse.body().getFeed().getEntries()));
     }
 
 }

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceContainer.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceContainer.java
@@ -1,0 +1,14 @@
+package com.novoda.github.reports.sheets.network;
+
+public class SheetsServiceContainer {
+
+    private static final SheetsApiService sheetsService = SheetsServiceFactory.newInstance().createService();
+
+    private SheetsServiceContainer() {
+        // no op
+    }
+
+    public static SheetsApiService getSheetsService() {
+        return sheetsService;
+    }
+}

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceFactory.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceFactory.java
@@ -1,0 +1,56 @@
+package com.novoda.github.reports.sheets.network;
+
+import com.novoda.github.reports.network.HttpClientFactory;
+import com.novoda.github.reports.network.OkHttpClientFactory;
+import com.novoda.github.reports.network.ServiceFactory;
+
+import okhttp3.OkHttpClient;
+import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public class SheetsServiceFactory extends ServiceFactory<SheetsApiService> {
+
+    // @RUI this is going to be an issue 'cause we don't just append on the endpoint
+    // https://spreadsheets.google.com/feeds/list/1rMeGnlugO312to0loBwN3x0QTvAxoHwv4Pe_SYXR1YE/1/public/basic?alt=json
+    // https://spreadsheets.google.com/feeds/list/{ID}/1/public/basic?alt=json
+    private static final String ENDPOINT = "https://spreadsheets.google.com/feeds/list/";
+
+    public static SheetsServiceFactory newInstance() {
+        //Interceptors floatInterceptors = FloatInterceptors.defaultInterceptors();
+        //HttpClientFactory httpClientFactory = OkHttpClientFactory.newInstance(floatInterceptors);
+        HttpClientFactory httpClientFactory = OkHttpClientFactory.newInstance();
+        return newInstance(httpClientFactory);
+    }
+
+    public static SheetsServiceFactory newCachingInstance() {
+        //Interceptors floatInterceptors = FloatInterceptors.defaultInterceptors();
+        //HttpClientFactory httpClientFactory = OkHttpClientFactory.newCachingInstance(floatInterceptors);
+        HttpClientFactory httpClientFactory = OkHttpClientFactory.newCachingInstance();
+        return newInstance(httpClientFactory);
+    }
+
+    private static SheetsServiceFactory newInstance(HttpClientFactory httpClientFactory) {
+        OkHttpClient okHttpClient = httpClientFactory.createClient();
+        GsonConverterFactory gsonConverterFactory = GsonConverterFactory.create();
+        RxJavaCallAdapterFactory rxJavaCallAdapterFactory = RxJavaCallAdapterFactory.create();
+        return new SheetsServiceFactory(okHttpClient, gsonConverterFactory, rxJavaCallAdapterFactory);
+    }
+
+    private SheetsServiceFactory(OkHttpClient okHttpClient,
+                                 GsonConverterFactory gsonConverterFactory,
+                                 RxJavaCallAdapterFactory rxJavaCallAdapterFactory) {
+
+        super(okHttpClient, gsonConverterFactory, rxJavaCallAdapterFactory);
+    }
+
+    @Override
+    protected Class<SheetsApiService> getServiceClass() {
+        return SheetsApiService.class;
+    }
+
+    @Override
+    protected String getBaseEndpoint() {
+        return ENDPOINT;
+    }
+
+}

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceFactory.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceFactory.java
@@ -10,21 +10,14 @@ import retrofit2.converter.gson.GsonConverterFactory;
 
 public class SheetsServiceFactory extends ServiceFactory<SheetsApiService> {
 
-    // @RUI this is going to be an issue 'cause we don't just append on the endpoint
-    // https://spreadsheets.google.com/feeds/list/1rMeGnlugO312to0loBwN3x0QTvAxoHwv4Pe_SYXR1YE/1/public/basic?alt=json
-    // https://spreadsheets.google.com/feeds/list/{ID}/1/public/basic?alt=json
     private static final String ENDPOINT = "https://spreadsheets.google.com/feeds/list/";
 
     public static SheetsServiceFactory newInstance() {
-        //Interceptors floatInterceptors = FloatInterceptors.defaultInterceptors();
-        //HttpClientFactory httpClientFactory = OkHttpClientFactory.newInstance(floatInterceptors);
         HttpClientFactory httpClientFactory = OkHttpClientFactory.newInstance();
         return newInstance(httpClientFactory);
     }
 
     public static SheetsServiceFactory newCachingInstance() {
-        //Interceptors floatInterceptors = FloatInterceptors.defaultInterceptors();
-        //HttpClientFactory httpClientFactory = OkHttpClientFactory.newCachingInstance(floatInterceptors);
         HttpClientFactory httpClientFactory = OkHttpClientFactory.newCachingInstance();
         return newInstance(httpClientFactory);
     }

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Content.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Content.java
@@ -1,0 +1,29 @@
+package com.novoda.github.reports.sheets.sheet;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Content {
+
+    private String type;
+
+    @SerializedName("$t")
+    private String value;
+
+    Content(String type, String value) {
+        this.type = type;
+        this.value = value;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "Content{type='" + type + "\', value='" + value + '\'' + "}";
+    }
+}

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Content.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Content.java
@@ -9,7 +9,7 @@ public class Content {
     @SerializedName("$t")
     private String value;
 
-    Content(String type, String value) {
+    public Content(String type, String value) {
         this.type = type;
         this.value = value;
     }

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Entry.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Entry.java
@@ -1,0 +1,22 @@
+package com.novoda.github.reports.sheets.sheet;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Entry {
+
+    @SerializedName("title")
+    private Content content;
+
+    Entry(Content content) {
+        this.content = content;
+    }
+
+    public Content getContent() {
+        return content;
+    }
+
+    @Override
+    public String toString() {
+        return "Entry{content=" + content + "}";
+    }
+}

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Entry.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Entry.java
@@ -5,18 +5,26 @@ import com.google.gson.annotations.SerializedName;
 public class Entry {
 
     @SerializedName("title")
-    private Content content;
+    private Content key;
 
-    Entry(Content content) {
-        this.content = content;
+    @SerializedName("content")
+    private Content value;
+
+    Entry(Content key, Content value) {
+        this.key = key;
+        this.value = value;
     }
 
-    public Content getContent() {
-        return content;
+    public Content getKey() {
+        return key;
+    }
+
+    public Content getValue() {
+        return value;
     }
 
     @Override
     public String toString() {
-        return "Entry{content=" + content + "}";
+        return "Entry{key=" + key + ", value=" + value + "}";
     }
 }

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Entry.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Entry.java
@@ -10,7 +10,7 @@ public class Entry {
     @SerializedName("content")
     private Content value;
 
-    Entry(Content key, Content value) {
+    public Entry(Content key, Content value) {
         this.key = key;
         this.value = value;
     }

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Feed.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Feed.java
@@ -9,7 +9,7 @@ public class Feed {
     @SerializedName("entry")
     private List<Entry> entries;
 
-    Feed(List<Entry> entries) {
+    public Feed(List<Entry> entries) {
         this.entries = entries;
     }
 

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Feed.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Feed.java
@@ -1,0 +1,24 @@
+package com.novoda.github.reports.sheets.sheet;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class Feed {
+
+    @SerializedName("entry")
+    private List<Entry> entries;
+
+    Feed(List<Entry> entries) {
+        this.entries = entries;
+    }
+
+    public List<Entry> getEntries() {
+        return entries;
+    }
+
+    @Override
+    public String toString() {
+        return "Feed{entries=" + entries + "}";
+    }
+}

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Sheet.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Sheet.java
@@ -1,0 +1,19 @@
+package com.novoda.github.reports.sheets.sheet;
+
+public class Sheet {
+
+    private Feed feed;
+
+    Sheet(Feed feed) {
+        this.feed = feed;
+    }
+
+    public Feed getFeed() {
+        return feed;
+    }
+
+    @Override
+    public String toString() {
+        return "Sheet{feed=" + feed + "}";
+    }
+}

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Sheet.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/sheet/Sheet.java
@@ -4,7 +4,7 @@ public class Sheet {
 
     private Feed feed;
 
-    Sheet(Feed feed) {
+    public Sheet(Feed feed) {
         this.feed = feed;
     }
 

--- a/sheets/src/test/java/com/novoda/github/reports/sheets/network/SheetsServiceClientTest.java
+++ b/sheets/src/test/java/com/novoda/github/reports/sheets/network/SheetsServiceClientTest.java
@@ -1,0 +1,73 @@
+package com.novoda.github.reports.sheets.network;
+
+import com.novoda.github.reports.sheets.sheet.Content;
+import com.novoda.github.reports.sheets.sheet.Entry;
+import com.novoda.github.reports.sheets.sheet.Feed;
+import com.novoda.github.reports.sheets.sheet.Sheet;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import retrofit2.Response;
+import rx.Observable;
+import rx.observers.TestSubscriber;
+import rx.schedulers.Schedulers;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class SheetsServiceClientTest {
+
+    @Mock
+    SheetsApiService mockSheetsApiService;
+
+    private TestSubscriber<Entry> testSubscriber;
+
+    private List<Entry> entries;
+
+    private Observable<Response<Sheet>> apiObservable;
+
+    private SheetsServiceClient sheetsServiceClient;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+
+        testSubscriber = new TestSubscriber<>();
+
+        entries = givenEntries();
+        Response<Sheet> response = Response.success(givenASheetWith(entries));
+        apiObservable = Observable.from(Collections.singletonList(response));
+
+        sheetsServiceClient = new SheetsServiceClient(mockSheetsApiService);
+    }
+
+    @Test
+    public void givenServiceReturnsDocument_whenQueryingForADocument_thenEachDocumentEntryIsEmitted() throws Exception {
+        given(mockSheetsApiService.getDocument(anyString())).willReturn(apiObservable);
+
+        sheetsServiceClient.getEntries()
+                .subscribeOn(Schedulers.immediate())
+                .subscribe(testSubscriber);
+
+        testSubscriber.assertReceivedOnNext(entries);
+    }
+
+    private Sheet givenASheetWith(List<Entry> entries) {
+        Feed feed = new Feed(entries);
+        return new Sheet(feed);
+    }
+
+    private List<Entry> givenEntries() {
+        Content key = new Content("keyType", "keyValue");
+        Content value = new Content("valueType", "valueValue");
+        Entry entry = new Entry(key, value);
+        return Collections.singletonList(entry);
+    }
+
+}


### PR DESCRIPTION
#### Problem

In order to avoid hard-coding user mappings (see the ![float module](https://github.com/novoda/github-reports/tree/master/float)), we should provide a way in which user mappings and, eventually, project mappings can be defined in a friendlier, non-dev/tech manner.

#### Solution

We aim to make it possible to configure these mappings through a ![Google Sheets](https://www.google.co.uk/sheets/about/) document, through which we can get the data from, on the github-reports side.

This PR introduces a new module - `sheets` - to contain all the classes used to get and parse the data from a sheets document.

##### Test(s) added

No, there's not much logic in the new classes, as they mostly set up a Retrofit service to get the data from. My feeling is that we'd be mocking everything and setting up the mocks to get what we want on each test.
