### PR TITLE
Read document id from a file

### DIFF
--- a/github-hooks-web-service/build.gradle
+++ b/github-hooks-web-service/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.0.71-beta'
-    testCompile 'org.assertj:assertj-core:3.5.2'
+    testCompile 'org.assertj:assertj-core:3.6.0'
 }
 
 jar {

--- a/sheets/build.gradle
+++ b/sheets/build.gradle
@@ -13,4 +13,5 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.0.71-beta'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
+    testCompile 'org.assertj:assertj-core:3.5.2'
 }

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/network/SheetsServiceClient.java
@@ -2,31 +2,33 @@ package com.novoda.github.reports.sheets.network;
 
 import com.novoda.github.reports.sheets.convert.GithubUsernameRemover;
 import com.novoda.github.reports.sheets.convert.ValueRemover;
+import com.novoda.github.reports.sheets.properties.DocumentIdReader;
 import com.novoda.github.reports.sheets.sheet.Entry;
 
 import rx.Observable;
 
 public class SheetsServiceClient {
 
-    // TODO extract to .json and read as prop
-    private static final String DOCUMENT_ID = "1rMeGnlugO312to0loBwN3x0QTvAxoHwv4Pe_SYXR1YE";
-
     private final SheetsApiService apiService;
     private final ValueRemover<Entry> keyRemover;
+    private final DocumentIdReader documentIdReader;
 
     public static SheetsServiceClient newInstance() {
         SheetsApiService apiService = SheetsServiceContainer.getSheetsService();
         ValueRemover<Entry> keyRemover = new GithubUsernameRemover();
-        return new SheetsServiceClient(apiService, keyRemover);
+        DocumentIdReader documentIdReader = DocumentIdReader.newInstance();
+        return new SheetsServiceClient(apiService, keyRemover, documentIdReader);
     }
 
-    SheetsServiceClient(SheetsApiService apiService, ValueRemover<Entry> keyRemover) {
+    SheetsServiceClient(SheetsApiService apiService, ValueRemover<Entry> keyRemover, DocumentIdReader documentIdReader) {
         this.apiService = apiService;
         this.keyRemover = keyRemover;
+        this.documentIdReader = documentIdReader;
     }
 
     public Observable<Entry> getEntries() {
-         return apiService.getEntries(DOCUMENT_ID)
+        String documentId = documentIdReader.getDocumentId();
+         return apiService.getEntries(documentId)
                  .map(keyRemover::removeFrom);
     }
 

--- a/sheets/src/main/java/com/novoda/github/reports/sheets/properties/DocumentIdReader.java
+++ b/sheets/src/main/java/com/novoda/github/reports/sheets/properties/DocumentIdReader.java
@@ -1,0 +1,25 @@
+package com.novoda.github.reports.sheets.properties;
+
+import com.novoda.github.reports.properties.PropertiesReader;
+
+public class DocumentIdReader {
+
+    private static final String SHEETS_PROPERTIES_FILENAME = "sheets.credentials";
+    private static final String DOCUMENT_ID_KEY = "DOCUMENT_ID";
+
+    private PropertiesReader propertiesReader;
+
+    public static DocumentIdReader newInstance() {
+        PropertiesReader propertiesReader = PropertiesReader.newInstance(SHEETS_PROPERTIES_FILENAME);
+        return new DocumentIdReader(propertiesReader);
+    }
+
+    private DocumentIdReader(PropertiesReader propertiesReader) {
+        this.propertiesReader = propertiesReader;
+    }
+
+    public String getDocumentId() {
+        return propertiesReader.readProperty(DOCUMENT_ID_KEY);
+    }
+
+}

--- a/sheets/src/main/resources/sheets.credentials.sample
+++ b/sheets/src/main/resources/sheets.credentials.sample
@@ -1,0 +1,1 @@
+DOCUMENT_ID=your_doc_id_here


### PR DESCRIPTION
#### Problem

We need to avoid hardcoding the document ID due to security concerns, as we only want a specific set of people to have that ID.

#### Solution

Use the solutions already in place for this, i.e., `*CredentialsReader`. This means the document ID will be stored in a properties file and its contents will be read when necessary. As we're git ignoring `*.credentials` files the file containing the ID won't be published to the repo.

##### Test(s) added

Yes.

Added assertJ as a test dependency 'cause it allows for more readable tests. I intend on updating some other tests (unrelated with this PR) later.