### PR TITLE
Integrate sheets

### DIFF
--- a/float/build.gradle
+++ b/float/build.gradle
@@ -9,6 +9,7 @@ repositories {
 dependencies {
     compile project(':core')
     compile project(':network')
+    compile project(':sheets')
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.0.71-beta'

--- a/float/build.gradle
+++ b/float/build.gradle
@@ -14,4 +14,5 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.0.71-beta'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
+    testCompile 'org.assertj:assertj-core:3.6.0'
 }

--- a/float/src/main/java/com/novoda/floatschedule/AssignmentServiceClient.java
+++ b/float/src/main/java/com/novoda/floatschedule/AssignmentServiceClient.java
@@ -1,11 +1,10 @@
 package com.novoda.floatschedule;
 
+import com.novoda.floatschedule.convert.FailedToLoadMappingsException;
 import com.novoda.floatschedule.convert.FloatGithubProjectConverter;
 import com.novoda.floatschedule.convert.FloatGithubUserConverter;
 import com.novoda.floatschedule.task.Task;
 import com.novoda.floatschedule.task.TaskServiceClient;
-import rx.Observable;
-import rx.functions.Func1;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -13,6 +12,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
+
+import rx.Observable;
+import rx.functions.Func1;
 
 public class AssignmentServiceClient {
 
@@ -84,7 +86,7 @@ public class AssignmentServiceClient {
         return floatUsername -> {
             try {
                 return floatGithubUserConverter.getGithubUser(floatUsername);
-            } catch (IOException e) {
+            } catch (FailedToLoadMappingsException e) {
                 e.printStackTrace();
                 return null;
             }

--- a/float/src/main/java/com/novoda/floatschedule/FloatServiceClient.java
+++ b/float/src/main/java/com/novoda/floatschedule/FloatServiceClient.java
@@ -1,22 +1,37 @@
 package com.novoda.floatschedule;
 
-import com.novoda.floatschedule.convert.*;
+import com.novoda.floatschedule.convert.FailedToLoadMappingsException;
+import com.novoda.floatschedule.convert.FloatDateConverter;
+import com.novoda.floatschedule.convert.FloatGithubProjectConverter;
+import com.novoda.floatschedule.convert.FloatGithubUserConverter;
+import com.novoda.floatschedule.convert.GithubToFloatUserMatchNotFoundException;
+import com.novoda.floatschedule.convert.NoMatchFoundException;
+import com.novoda.floatschedule.convert.NumberOfWeeksCalculator;
 import com.novoda.floatschedule.people.PeopleServiceClient;
 import com.novoda.floatschedule.people.Person;
 import com.novoda.floatschedule.task.Task;
 import com.novoda.floatschedule.task.TaskServiceClient;
 import com.novoda.github.reports.data.model.UserAssignments;
+
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import rx.Observable;
 import rx.functions.Action2;
 import rx.functions.Func0;
 import rx.functions.Func1;
 import rx.internal.util.UtilityFunctions;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 public class FloatServiceClient {
 
@@ -79,13 +94,13 @@ public class FloatServiceClient {
         String floatUsername;
         try {
             floatUsername = getFloatUsername(githubUsername);
-        } catch (IOException e) {
+        } catch (FailedToLoadMappingsException e) {
             return Observable.error(e);
         }
         return getTasksForFloatUser(floatUsername, startDate, numberOfWeeks, timezone);
     }
 
-    private String getFloatUsername(String githubUsername) throws IOException, NoMatchFoundException {
+    private String getFloatUsername(String githubUsername) throws FailedToLoadMappingsException, NoMatchFoundException {
         return floatGithubUserConverter.getFloatUser(githubUsername);
     }
 
@@ -127,7 +142,7 @@ public class FloatServiceClient {
     private List<String> getGithubUsersOrEmpty() {
         try {
             return floatGithubUserConverter.getGithubUsers();
-        } catch (IOException e) {
+        } catch (FailedToLoadMappingsException e) {
             return Collections.emptyList();
         }
     }
@@ -178,7 +193,7 @@ public class FloatServiceClient {
             try {
                 String floatUsername = floatGithubUserConverter.getFloatUser(githubUsername);
                 return new AbstractMap.SimpleImmutableEntry<>(floatUsername, githubUsername);
-            } catch (IOException e) {
+            } catch (FailedToLoadMappingsException e) {
                 throw new GithubToFloatUserMatchNotFoundException(e);
             }
         };
@@ -254,7 +269,7 @@ public class FloatServiceClient {
     private List<String> getRepositoriesFor(Task task) {
         try {
             return floatGithubProjectConverter.getRepositories(task.getProjectName());
-        } catch (IOException | NoMatchFoundException e) {
+        } catch (FailedToLoadMappingsException | NoMatchFoundException e) {
             // ignored
         }
         return Collections.emptyList();

--- a/float/src/main/java/com/novoda/floatschedule/FloatServiceClient.java
+++ b/float/src/main/java/com/novoda/floatschedule/FloatServiceClient.java
@@ -13,7 +13,6 @@ import com.novoda.floatschedule.task.Task;
 import com.novoda.floatschedule.task.TaskServiceClient;
 import com.novoda.github.reports.data.model.UserAssignments;
 
-import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -77,7 +76,7 @@ public class FloatServiceClient {
     }
 
     Observable<String> getRepositoryNamesForGithubUser(String githubUsername, Date startDate, int numberOfWeeks, TimeZone timezone)
-            throws IOException, NoMatchFoundException {
+            throws FailedToLoadMappingsException, NoMatchFoundException {
 
         return getRepositoryNamesForFloatUser(getFloatUsername(githubUsername), startDate, numberOfWeeks, timezone);
     }

--- a/float/src/main/java/com/novoda/floatschedule/convert/FailedToLoadMappingsException.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/FailedToLoadMappingsException.java
@@ -1,0 +1,10 @@
+package com.novoda.floatschedule.convert;
+
+import java.io.IOException;
+
+public class FailedToLoadMappingsException extends RuntimeException {
+
+    FailedToLoadMappingsException(IOException cause) {
+        super(cause);
+    }
+}

--- a/float/src/main/java/com/novoda/floatschedule/convert/FloatGithubProjectConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/FloatGithubProjectConverter.java
@@ -55,7 +55,7 @@ public class FloatGithubProjectConverter {
         return projectName -> projectName != null;
     }
 
-    public List<String> getRepositories(String floatProject) throws IOException, NoMatchFoundException {
+    public List<String> getRepositories(String floatProject) throws FailedToLoadMappingsException, NoMatchFoundException {
         readIfNeeded();
         return projectsReader.getContent().entrySet()
                 .stream()
@@ -65,11 +65,15 @@ public class FloatGithubProjectConverter {
                 .orElseThrow(noMatchFoundException(floatProject));
     }
 
-    private void readIfNeeded() throws IOException {
+    private void readIfNeeded() throws FailedToLoadMappingsException {
         if (projectsReader.hasContent()) {
             return;
         }
-        projectsReader.read();
+        try {
+            projectsReader.read();
+        } catch (IOException exception) {
+            throw new FailedToLoadMappingsException(exception);
+        }
     }
 
     private Predicate<Map.Entry<String, List<String>>> byProjectHavingRepositories(String floatProject) {

--- a/float/src/main/java/com/novoda/floatschedule/convert/FloatGithubUserConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/FloatGithubUserConverter.java
@@ -5,11 +5,13 @@ import com.novoda.github.reports.reader.UsersReader;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class FloatGithubUserConverter {
+import static com.novoda.floatschedule.convert.FloatNameFilter.byFloatName;
+import static com.novoda.floatschedule.convert.GithubUsernameFilter.byGithubUsername;
+import static com.novoda.floatschedule.convert.NoMatchFoundException.noMatchFoundExceptionFor;
+
+public class FloatGithubUserConverter implements GithubUserConverter {
 
     private final UsersReader usersReader;
 
@@ -36,7 +38,7 @@ public class FloatGithubUserConverter {
                 .filter(byGithubUsername(githubUsername))
                 .findFirst()
                 .map(Map.Entry::getKey)
-                .orElseThrow(noMatchFoundException(githubUsername));
+                .orElseThrow(noMatchFoundExceptionFor(githubUsername));
     }
 
     private void readIfNeeded() throws IOException {
@@ -46,25 +48,14 @@ public class FloatGithubUserConverter {
         usersReader.read();
     }
 
-    private Predicate<Map.Entry<String, String>> byGithubUsername(String githubUsername) {
-        return entry -> entry.getValue().equalsIgnoreCase(githubUsername);
-    }
-
-    private Supplier<RuntimeException> noMatchFoundException(String username) {
-        return () -> new NoMatchFoundException(username);
-    }
-
     public String getGithubUser(String floatName) throws IOException, NoMatchFoundException {
         readIfNeeded();
         return usersReader.getContent().entrySet()
                 .stream()
-                .filter(byFloatUsername(floatName))
+                .filter(byFloatName(floatName))
                 .findFirst()
                 .map(Map.Entry::getValue)
-                .orElseThrow(noMatchFoundException(floatName));
+                .orElseThrow(noMatchFoundExceptionFor(floatName));
     }
 
-    private Predicate<Map.Entry<String, String>> byFloatUsername(String floatName) {
-        return entry -> entry.getKey().equalsIgnoreCase(floatName);
-    }
 }

--- a/float/src/main/java/com/novoda/floatschedule/convert/FloatGithubUserConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/FloatGithubUserConverter.java
@@ -34,7 +34,8 @@ public class FloatGithubUserConverter implements GithubUserConverter {
 
     public String getFloatUser(String githubUsername) throws IOException, NoMatchFoundException {
         readIfNeeded();
-        return usersReader.getContent().entrySet().stream()
+        return usersReader.getContent().entrySet()
+                .stream()
                 .filter(byGithubUsername(githubUsername))
                 .findFirst()
                 .map(Map.Entry::getKey)

--- a/float/src/main/java/com/novoda/floatschedule/convert/FloatGithubUserConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/FloatGithubUserConverter.java
@@ -23,7 +23,7 @@ public class FloatGithubUserConverter implements GithubUserConverter {
         this.usersReader = usersReader;
     }
 
-    public List<String> getGithubUsers() throws IOException {
+    public List<String> getGithubUsers() throws FailedToLoadMappingsException {
         readIfNeeded();
         return usersReader.getContent()
                 .entrySet()
@@ -32,7 +32,7 @@ public class FloatGithubUserConverter implements GithubUserConverter {
                 .collect(Collectors.toList());
     }
 
-    public String getFloatUser(String githubUsername) throws IOException, NoMatchFoundException {
+    public String getFloatUser(String githubUsername) throws FailedToLoadMappingsException, NoMatchFoundException {
         readIfNeeded();
         return usersReader.getContent().entrySet()
                 .stream()
@@ -42,14 +42,18 @@ public class FloatGithubUserConverter implements GithubUserConverter {
                 .orElseThrow(noMatchFoundExceptionFor(githubUsername));
     }
 
-    private void readIfNeeded() throws IOException {
+    private void readIfNeeded() throws FailedToLoadMappingsException {
         if (usersReader.hasContent()) {
             return;
         }
-        usersReader.read();
+        try {
+            usersReader.read();
+        } catch (IOException exception) {
+            throw new FailedToLoadMappingsException(exception);
+        }
     }
 
-    public String getGithubUser(String floatName) throws IOException, NoMatchFoundException {
+    public String getGithubUser(String floatName) throws FailedToLoadMappingsException, NoMatchFoundException {
         readIfNeeded();
         return usersReader.getContent().entrySet()
                 .stream()

--- a/float/src/main/java/com/novoda/floatschedule/convert/FloatNameFilter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/FloatNameFilter.java
@@ -1,0 +1,23 @@
+package com.novoda.floatschedule.convert;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+class FloatNameFilter implements Predicate<Map.Entry<String, String>> {
+
+    private final String floatName;
+
+    static FloatNameFilter byFloatName(String floatName) {
+        return new FloatNameFilter(floatName);
+    }
+
+    private FloatNameFilter(String floatName) {
+        this.floatName = floatName;
+    }
+
+    @Override
+    public boolean test(Map.Entry<String, String> floatNameToGithubUserName) {
+        return floatNameToGithubUserName.getKey().equalsIgnoreCase(floatName);
+    }
+
+}

--- a/float/src/main/java/com/novoda/floatschedule/convert/GithubUserConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/GithubUserConverter.java
@@ -1,0 +1,15 @@
+package com.novoda.floatschedule.convert;
+
+import java.util.List;
+
+public interface GithubUserConverter {
+
+    // @RUI revise the use of 'Expression' here and borrow it down
+
+    List<String> getGithubUsers() throws Exception;
+
+    String getFloatUser(String githubUsername) throws Exception;
+
+    String getGithubUser(String floatName) throws Exception;
+
+}

--- a/float/src/main/java/com/novoda/floatschedule/convert/GithubUserConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/GithubUserConverter.java
@@ -3,11 +3,11 @@ package com.novoda.floatschedule.convert;
 import java.util.List;
 
 public interface GithubUserConverter {
-    
-    List<String> getGithubUsers() throws Exception;
 
-    String getFloatUser(String githubUsername) throws Exception;
+    List<String> getGithubUsers();
 
-    String getGithubUser(String floatName) throws Exception;
+    String getFloatUser(String githubUsername) throws NoMatchFoundException;
+
+    String getGithubUser(String floatName) throws NoMatchFoundException;
 
 }

--- a/float/src/main/java/com/novoda/floatschedule/convert/GithubUserConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/GithubUserConverter.java
@@ -3,9 +3,7 @@ package com.novoda.floatschedule.convert;
 import java.util.List;
 
 public interface GithubUserConverter {
-
-    // @RUI revise the use of 'Expression' here and borrow it down
-
+    
     List<String> getGithubUsers() throws Exception;
 
     String getFloatUser(String githubUsername) throws Exception;

--- a/float/src/main/java/com/novoda/floatschedule/convert/GithubUsernameFilter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/GithubUsernameFilter.java
@@ -1,0 +1,23 @@
+package com.novoda.floatschedule.convert;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+class GithubUsernameFilter implements Predicate<Map.Entry<String, String>> {
+
+    private final String githubUsername;
+
+    static GithubUsernameFilter byGithubUsername(String githubUsername) {
+        return new GithubUsernameFilter(githubUsername);
+    }
+
+    private GithubUsernameFilter(String githubUsername) {
+        this.githubUsername = githubUsername;
+    }
+
+    @Override
+    public boolean test(Map.Entry<String, String> floatNameToGithubUserName) {
+        return floatNameToGithubUserName.getValue().equalsIgnoreCase(githubUsername);
+    }
+
+}

--- a/float/src/main/java/com/novoda/floatschedule/convert/NoMatchFoundException.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/NoMatchFoundException.java
@@ -1,8 +1,15 @@
 package com.novoda.floatschedule.convert;
 
+import java.util.function.Supplier;
+
 public class NoMatchFoundException extends RuntimeException {
+
+    static Supplier<NoMatchFoundException> noMatchFoundExceptionFor(String target) {
+        return () -> new NoMatchFoundException(target);
+    }
 
     NoMatchFoundException(String target) {
         super("Unable to find a match for \"" + target + "\". Please check the mappings file and/or your query input.");
     }
+
 }

--- a/float/src/main/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverter.java
@@ -67,7 +67,7 @@ public class SheetsFloatGithubUserConverter implements GithubUserConverter {
                 .stream()
                 .filter(byFloatName(floatName))
                 .findFirst()
-                .map(Map.Entry::getKey)
+                .map(Map.Entry::getValue)
                 .orElseThrow(noMatchFoundExceptionFor(floatName));
     }
 

--- a/float/src/main/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverter.java
@@ -1,0 +1,4 @@
+package com.novoda.floatschedule.convert;
+
+public class SheetsFloatGithubUserConverter {
+}

--- a/float/src/main/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverter.java
@@ -29,7 +29,7 @@ public class SheetsFloatGithubUserConverter implements GithubUserConverter {
     }
 
     @Override
-    public List<String> getGithubUsers() throws Exception {
+    public List<String> getGithubUsers() {
         readIfNeeded();
         return floatToGithubUser.values()
                 .stream()
@@ -46,7 +46,7 @@ public class SheetsFloatGithubUserConverter implements GithubUserConverter {
     }
 
     @Override
-    public String getFloatUser(String githubUsername) throws Exception {
+    public String getFloatUser(String githubUsername) throws NoMatchFoundException {
         readIfNeeded();
         return floatToGithubUser.entrySet()
                 .stream()
@@ -57,7 +57,7 @@ public class SheetsFloatGithubUserConverter implements GithubUserConverter {
     }
 
     @Override
-    public String getGithubUser(String floatName) throws Exception {
+    public String getGithubUser(String floatName) throws NoMatchFoundException {
         readIfNeeded();
         return floatToGithubUser.entrySet()
                 .stream()

--- a/float/src/main/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverter.java
@@ -1,4 +1,74 @@
 package com.novoda.floatschedule.convert;
 
-public class SheetsFloatGithubUserConverter {
+import com.novoda.github.reports.sheets.network.SheetsServiceClient;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
+
+import static com.novoda.floatschedule.convert.FloatNameFilter.byFloatName;
+import static com.novoda.floatschedule.convert.GithubUsernameFilter.byGithubUsername;
+import static com.novoda.floatschedule.convert.NoMatchFoundException.noMatchFoundExceptionFor;
+
+public class SheetsFloatGithubUserConverter implements GithubUserConverter {
+
+    private final Map<String, String> floatToGithubUser;
+    private final Scheduler scheduler;
+    private final SheetsServiceClient sheetsServiceClient;
+
+    public static SheetsFloatGithubUserConverter newInstance() {
+        Scheduler scheduler = Schedulers.immediate();
+        SheetsServiceClient sheetsServiceClient = SheetsServiceClient.newInstance();
+        return new SheetsFloatGithubUserConverter(sheetsServiceClient, scheduler);
+    }
+
+    SheetsFloatGithubUserConverter(SheetsServiceClient sheetsServiceClient, Scheduler scheduler) {
+        floatToGithubUser = new HashMap<>();
+        this.scheduler = scheduler;
+        this.sheetsServiceClient = sheetsServiceClient;
+    }
+
+    @Override
+    public List<String> getGithubUsers() throws Exception {
+        readIfNeeded();
+        return floatToGithubUser.values()
+                .stream()
+                .collect(Collectors.toList());
+    }
+
+    private void readIfNeeded() {
+        if (!floatToGithubUser.isEmpty()) {
+            return;
+        }
+        sheetsServiceClient.getEntries()
+                .subscribeOn(scheduler)
+                .subscribe(entry -> floatToGithubUser.put(entry.getTitle(), entry.getContent()));
+    }
+
+    @Override
+    public String getFloatUser(String githubUsername) throws Exception {
+        readIfNeeded();
+        return floatToGithubUser.entrySet()
+                .stream()
+                .filter(byGithubUsername(githubUsername))
+                .findFirst()
+                .map(Map.Entry::getKey)
+                .orElseThrow(noMatchFoundExceptionFor(githubUsername));
+    }
+
+    @Override
+    public String getGithubUser(String floatName) throws Exception {
+        readIfNeeded();
+        return floatToGithubUser.entrySet()
+                .stream()
+                .filter(byFloatName(floatName))
+                .findFirst()
+                .map(Map.Entry::getKey)
+                .orElseThrow(noMatchFoundExceptionFor(floatName));
+    }
+
 }

--- a/float/src/main/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverter.java
+++ b/float/src/main/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverter.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import rx.Scheduler;
 import rx.schedulers.Schedulers;
 
 import static com.novoda.floatschedule.convert.FloatNameFilter.byFloatName;
@@ -17,18 +16,15 @@ import static com.novoda.floatschedule.convert.NoMatchFoundException.noMatchFoun
 public class SheetsFloatGithubUserConverter implements GithubUserConverter {
 
     private final Map<String, String> floatToGithubUser;
-    private final Scheduler scheduler;
     private final SheetsServiceClient sheetsServiceClient;
 
     public static SheetsFloatGithubUserConverter newInstance() {
-        Scheduler scheduler = Schedulers.immediate();
         SheetsServiceClient sheetsServiceClient = SheetsServiceClient.newInstance();
-        return new SheetsFloatGithubUserConverter(sheetsServiceClient, scheduler);
+        return new SheetsFloatGithubUserConverter(sheetsServiceClient);
     }
 
-    SheetsFloatGithubUserConverter(SheetsServiceClient sheetsServiceClient, Scheduler scheduler) {
+    SheetsFloatGithubUserConverter(SheetsServiceClient sheetsServiceClient) {
         floatToGithubUser = new HashMap<>();
-        this.scheduler = scheduler;
         this.sheetsServiceClient = sheetsServiceClient;
     }
 
@@ -45,7 +41,7 @@ public class SheetsFloatGithubUserConverter implements GithubUserConverter {
             return;
         }
         sheetsServiceClient.getEntries()
-                .subscribeOn(scheduler)
+                .subscribeOn(Schedulers.immediate())
                 .subscribe(entry -> floatToGithubUser.put(entry.getTitle(), entry.getContent()));
     }
 

--- a/float/src/test/java/com/novoda/floatschedule/AssignmentServiceClientTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/AssignmentServiceClientTest.java
@@ -1,21 +1,27 @@
 package com.novoda.floatschedule;
 
+import com.novoda.floatschedule.convert.FailedToLoadMappingsException;
 import com.novoda.floatschedule.convert.FloatDateConverter;
 import com.novoda.floatschedule.convert.FloatGithubProjectConverter;
 import com.novoda.floatschedule.convert.FloatGithubUserConverter;
 import com.novoda.floatschedule.task.Task;
 import com.novoda.floatschedule.task.TaskServiceClient;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
 import rx.Observable;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
-
-import java.io.IOException;
-import java.time.Instant;
-import java.util.*;
 
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
@@ -86,7 +92,7 @@ public class AssignmentServiceClientTest {
     private void givenGithubUser(String githubUsername, String floatUsername) {
         try {
             when(mockFloatGithubUserConverter.getGithubUser(floatUsername)).thenReturn(githubUsername);
-        } catch (IOException e) {
+        } catch (FailedToLoadMappingsException e) {
             // nothing
         }
     }

--- a/float/src/test/java/com/novoda/floatschedule/FloatServiceClientTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/FloatServiceClientTest.java
@@ -1,11 +1,32 @@
 package com.novoda.floatschedule;
 
-import com.novoda.floatschedule.convert.*;
+import com.novoda.floatschedule.convert.FailedToLoadMappingsException;
+import com.novoda.floatschedule.convert.FloatDateConverter;
+import com.novoda.floatschedule.convert.FloatGithubProjectConverter;
+import com.novoda.floatschedule.convert.FloatGithubUserConverter;
+import com.novoda.floatschedule.convert.GithubToFloatUserMatchNotFoundException;
+import com.novoda.floatschedule.convert.NoMatchFoundException;
+import com.novoda.floatschedule.convert.NumberOfWeeksCalculator;
 import com.novoda.floatschedule.people.PeopleServiceClient;
 import com.novoda.floatschedule.people.Person;
 import com.novoda.floatschedule.task.Task;
 import com.novoda.floatschedule.task.TaskServiceClient;
 import com.novoda.github.reports.data.model.UserAssignments;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,13 +34,9 @@ import org.junit.rules.ExpectedException;
 import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
 import rx.Observable;
 import rx.functions.Action1;
-
-import java.io.IOException;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.*;
 
 import static com.novoda.floatschedule.TestSubscriberAssert.assertThatAnObservable;
 import static java.util.Arrays.asList;
@@ -242,14 +259,14 @@ public class FloatServiceClientTest {
 
     @Test
     public void givenFailingFloatUsernameLookup_whenGettingTasksForGithubUser_thenWeGetErroringObservable()
-            throws IOException {
+            throws FailedToLoadMappingsException {
 
         given(mockFloatGithubUserConverter).failsLookupForGithubUsername(GITHUB_MARIO);
 
         Observable<Task> actual = floatServiceClient
                 .getTasksForGithubUser(GITHUB_MARIO, ANY_START_DATE, ANY_NUMBER_OF_WEEKS, ANY_TIMEZONE);
 
-        assertThatAnObservable(actual).hasThrown(IOException.class);
+        assertThatAnObservable(actual).hasThrown(FailedToLoadMappingsException.class);
     }
 
     @Test
@@ -267,7 +284,7 @@ public class FloatServiceClientTest {
 
     @Test
     public void givenListOfGithubUsernamesWithUsernameNotMatchedInFloat_whenConvertToFloatUsernames_thenThrowGithubToFloatUserMatchNotFoundException()
-            throws IOException {
+            throws FailedToLoadMappingsException {
 
         // given
         String nonExistingGithubUsername = "this-user-does-not-exist-on-float";
@@ -422,8 +439,8 @@ public class FloatServiceClientTest {
             return this;
         }
 
-        GivenFloatGithubUserConverter failsLookupForGithubUsername(String githubUsername) throws IOException {
-            BDDMockito.given(floatGithubUserConverter.getFloatUser(githubUsername)).willThrow(IOException.class);
+        GivenFloatGithubUserConverter failsLookupForGithubUsername(String githubUsername) throws FailedToLoadMappingsException {
+            BDDMockito.given(floatGithubUserConverter.getFloatUser(githubUsername)).willThrow(FailedToLoadMappingsException.class);
             return this;
         }
     }

--- a/float/src/test/java/com/novoda/floatschedule/FloatServiceClientTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/FloatServiceClientTest.java
@@ -13,7 +13,6 @@ import com.novoda.floatschedule.task.Task;
 import com.novoda.floatschedule.task.TaskServiceClient;
 import com.novoda.github.reports.data.model.UserAssignments;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.AbstractMap;
@@ -169,7 +168,7 @@ public class FloatServiceClientTest {
 
     @Test
     public void givenAllTasks_whenGettingRepositoryNamesForGithubUser_thenTheExpectedRepositoryNamesAreEmitted()
-            throws IOException, NoMatchFoundException {
+            throws FailedToLoadMappingsException, NoMatchFoundException {
 
         given(mockTaskServiceClient).hasAllTasks();
 
@@ -428,13 +427,13 @@ public class FloatServiceClientTest {
             this.floatGithubUserConverter = floatGithubUserConverter;
         }
 
-        GivenFloatGithubUserConverter hasMapping(String githubUsername, String floatUsername) throws IOException {
+        GivenFloatGithubUserConverter hasMapping(String githubUsername, String floatUsername) throws FailedToLoadMappingsException {
             BDDMockito.given(floatGithubUserConverter.getGithubUser(floatUsername)).willReturn(githubUsername);
             BDDMockito.given(floatGithubUserConverter.getFloatUser(githubUsername)).willReturn(floatUsername);
             return this;
         }
 
-        GivenFloatGithubUserConverter hasGithubUsers(String... githubUsernames) throws IOException {
+        GivenFloatGithubUserConverter hasGithubUsers(String... githubUsernames) throws FailedToLoadMappingsException {
             BDDMockito.given(floatGithubUserConverter.getGithubUsers()).willReturn(asList(githubUsernames));
             return this;
         }

--- a/float/src/test/java/com/novoda/floatschedule/convert/FloatGithubUserConverterTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/convert/FloatGithubUserConverterTest.java
@@ -1,6 +1,14 @@
 package com.novoda.floatschedule.convert;
 
 import com.novoda.github.reports.reader.UsersReader;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.hamcrest.text.IsEqualIgnoringCase;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,12 +16,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.internal.verification.VerificationModeFactory;
 
-import java.io.IOException;
-import java.util.*;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -98,9 +104,9 @@ public class FloatGithubUserConverterTest {
 
         verify(mockUsersReader, VerificationModeFactory.times(0)).read();
     }
-    
+
     @Test
-    public void givenUsersWhereRead_whenGettingGithubUsers_thenReturnAllUsers() throws IOException {
+    public void givenUsersWhereRead_whenGettingGithubUsers_thenReturnAllUsers() {
         given(mockUsersReader.hasContent()).willReturn(true);
 
         List<String> actualGithubUsers = floatGithubUserConverter.getGithubUsers();
@@ -109,7 +115,7 @@ public class FloatGithubUserConverterTest {
     }
 
     @Test
-    public void givenUsersWereReadAndHaveNoContent_whenGettingGithubUsers_thenReturnAllUsers() throws IOException {
+    public void givenUsersWereReadAndHaveNoContent_whenGettingGithubUsers_thenReturnAllUsers() {
         given(mockUsersReader.hasContent()).willReturn(true);
         given(mockUsersReader.getContent()).willReturn(Collections.emptyMap());
 
@@ -117,4 +123,27 @@ public class FloatGithubUserConverterTest {
 
         assertEquals(Collections.emptyList(), actualGithubUsers);
     }
+
+    @Test(expected = FailedToLoadMappingsException.class)
+    public void givenUsersReaderFails_whenGettingGithubUsers_thenAnExceptionIsThrown() throws Exception {
+        willThrow(IOException.class).given(mockUsersReader).read();
+
+        floatGithubUserConverter.getGithubUsers();
+
+    }
+
+    @Test(expected = FailedToLoadMappingsException.class)
+    public void givenUsersWereReadButThereIsNoMatch_whenGettingTheFloatUsernameForAGithubUsername_thenThrowsFailedToLoadMappingsException() throws Exception {
+        willThrow(IOException.class).given(mockUsersReader).read();
+
+        floatGithubUserConverter.getFloatUser("sebastião");
+    }
+
+    @Test(expected = FailedToLoadMappingsException.class)
+    public void givenUsersWereReadButThereIsNoMatch_whenGettingTheGithubUsernameForAFloatUsername_thenThrowsFailedToLoadMappingsException() throws Exception {
+        willThrow(IOException.class).given(mockUsersReader).read();
+
+        floatGithubUserConverter.getGithubUser("palerma");
+    }
+
 }

--- a/float/src/test/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverterTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverterTest.java
@@ -7,19 +7,15 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.hamcrest.text.IsEqualIgnoringCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.internal.verification.VerificationModeFactory;
 
 import rx.Observable;
 import rx.schedulers.Schedulers;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class SheetsFloatGithubUserConverterTest {
@@ -41,13 +37,14 @@ public class SheetsFloatGithubUserConverterTest {
 
         String actual = sheetsFloatGithubUserConverter.getFloatUser("github meirinho");
 
-        assertThat("float pirata", IsEqualIgnoringCase.equalToIgnoringCase(actual));
+        assertThat(actual).isEqualToIgnoringCase("float pirata");
     }
 
     @Test(expected = NoMatchFoundException.class)
-    public void givenUsersWereReadButThereIsNoMatch_whenGettingTheFloatUsernameForAGithubUsername_thenThrowsException() throws Exception {
+    public void givenThereIsNoMatch_whenGettingTheFloatUsernameForAGithubUsername_thenThrowsException() throws Exception {
 
         sheetsFloatGithubUserConverter.getFloatUser("sebastião");
+
     }
 
     @Test
@@ -55,47 +52,14 @@ public class SheetsFloatGithubUserConverterTest {
 
         String actual = sheetsFloatGithubUserConverter.getGithubUser("float pirata");
 
-        assertThat("github meirinho", IsEqualIgnoringCase.equalToIgnoringCase(actual));
+        assertThat(actual).isEqualToIgnoringCase("github meirinho");
     }
 
     @Test(expected = NoMatchFoundException.class)
     public void givenUsersWereReadButThereIsNoMatch_whenGettingTheGithubUsernameForAFloatUsername_thenThrowsException() throws Exception {
 
         sheetsFloatGithubUserConverter.getGithubUser("palerma");
-    }
 
-    @Test
-    public void givenUsersWereNotRead_whenGettingTheGithubUsername_thenContentIsRead() throws Exception {
-        given(mockSheetsServiceClient.getEntries()).willReturn(Observable.from(Collections.emptyList()));
-
-        sheetsFloatGithubUserConverter.getGithubUser("float pirata");
-
-        verify(mockSheetsServiceClient).getEntries();
-    }
-
-    @Test
-    public void givenUsersWereAlreadyRead_whenGettingTheGithubUsernameAgain_thenContentIsNotReadAgain() throws Exception {
-
-        sheetsFloatGithubUserConverter.getGithubUser("float pirata");
-
-        verify(mockSheetsServiceClient, VerificationModeFactory.times(0)).getEntries();
-    }
-
-    @Test
-    public void givenUsersWereNotRead_whenGettingTheFloatUsername_thenContentIsRead() throws Exception {
-        given(mockSheetsServiceClient.getEntries()).willReturn(Observable.from(Collections.emptyList()));
-
-        sheetsFloatGithubUserConverter.getFloatUser("github meirinho");
-
-        verify(mockSheetsServiceClient).getEntries();
-    }
-
-    @Test
-    public void givenUsersWereAlreadyRead_whenGettingTheFloatUsernameAgain_thenContentIsNotReadAgain() throws Exception {
-
-        sheetsFloatGithubUserConverter.getFloatUser("github meirinho");
-
-        verify(mockSheetsServiceClient, VerificationModeFactory.times(0)).getEntries();
     }
 
     @Test
@@ -103,16 +67,16 @@ public class SheetsFloatGithubUserConverterTest {
 
         List<String> actualGithubUsers = sheetsFloatGithubUserConverter.getGithubUsers();
 
-        assertEquals(Arrays.asList("github meirinho", "sparrow"), actualGithubUsers);
+        assertThat(actualGithubUsers).containsExactlyInAnyOrder("github meirinho", "sparrow");
     }
 
     @Test
-    public void givenUsersWereReadAndHaveNoContent_whenGettingGithubUsers_thenReturnAllUsers() throws Exception {
+    public void givenThereAreNoUsers_whenGettingGithubUsers_thenReturnAllUsers() throws Exception {
         given(mockSheetsServiceClient.getEntries()).willReturn(Observable.from(Collections.emptyList()));
 
         List<String> actualGithubUsers = sheetsFloatGithubUserConverter.getGithubUsers();
 
-        assertEquals(Collections.emptyList(), actualGithubUsers);
+        assertThat(actualGithubUsers).isEmpty();
     }
 
     private List<Entry> givenEntries() {

--- a/float/src/test/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverterTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverterTest.java
@@ -1,0 +1,124 @@
+package com.novoda.floatschedule.convert;
+
+import com.novoda.github.reports.sheets.network.SheetsServiceClient;
+import com.novoda.github.reports.sheets.sheet.Entry;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.hamcrest.text.IsEqualIgnoringCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.internal.verification.VerificationModeFactory;
+
+import rx.Observable;
+import rx.schedulers.Schedulers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class SheetsFloatGithubUserConverterTest {
+
+    @Mock
+    SheetsServiceClient mockSheetsServiceClient;
+
+    private SheetsFloatGithubUserConverter sheetsFloatGithubUserConverter;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        given(mockSheetsServiceClient.getEntries()).willReturn(Observable.from(givenEntries()));
+        sheetsFloatGithubUserConverter = new SheetsFloatGithubUserConverter(mockSheetsServiceClient, Schedulers.immediate());
+    }
+
+    @Test
+    public void givenUsersWereRead_whenGettingTheFloatUsernameForAGithubUsername_thenReturnsMatch() throws Exception {
+
+        String actual = sheetsFloatGithubUserConverter.getFloatUser("github meirinho");
+
+        assertThat("float pirata", IsEqualIgnoringCase.equalToIgnoringCase(actual));
+    }
+
+    @Test(expected = NoMatchFoundException.class)
+    public void givenUsersWereReadButThereIsNoMatch_whenGettingTheFloatUsernameForAGithubUsername_thenThrowsException() throws Exception {
+
+        sheetsFloatGithubUserConverter.getFloatUser("sebastião");
+    }
+
+    @Test
+    public void givenUsersWereRead_whenGettingTheGithubUsernameForAFloatUsername_thenReturnsMatch() throws Exception {
+
+        String actual = sheetsFloatGithubUserConverter.getGithubUser("float pirata");
+
+        assertThat("github meirinho", IsEqualIgnoringCase.equalToIgnoringCase(actual));
+    }
+
+    @Test(expected = NoMatchFoundException.class)
+    public void givenUsersWereReadButThereIsNoMatch_whenGettingTheGithubUsernameForAFloatUsername_thenThrowsException() throws Exception {
+
+        sheetsFloatGithubUserConverter.getGithubUser("palerma");
+    }
+
+    @Test
+    public void givenUsersWereNotRead_whenGettingTheGithubUsername_thenContentIsRead() throws Exception {
+        given(mockSheetsServiceClient.getEntries()).willReturn(Observable.from(Collections.emptyList()));
+
+        sheetsFloatGithubUserConverter.getGithubUser("float pirata");
+
+        verify(mockSheetsServiceClient).getEntries();
+    }
+
+    @Test
+    public void givenUsersWereAlreadyRead_whenGettingTheGithubUsernameAgain_thenContentIsNotReadAgain() throws Exception {
+
+        sheetsFloatGithubUserConverter.getGithubUser("float pirata");
+
+        verify(mockSheetsServiceClient, VerificationModeFactory.times(0)).getEntries();
+    }
+
+    @Test
+    public void givenUsersWereNotRead_whenGettingTheFloatUsername_thenContentIsRead() throws Exception {
+        given(mockSheetsServiceClient.getEntries()).willReturn(Observable.from(Collections.emptyList()));
+
+        sheetsFloatGithubUserConverter.getFloatUser("github meirinho");
+
+        verify(mockSheetsServiceClient).getEntries();
+    }
+
+    @Test
+    public void givenUsersWereAlreadyRead_whenGettingTheFloatUsernameAgain_thenContentIsNotReadAgain() throws Exception {
+
+        sheetsFloatGithubUserConverter.getFloatUser("github meirinho");
+
+        verify(mockSheetsServiceClient, VerificationModeFactory.times(0)).getEntries();
+    }
+
+    @Test
+    public void givenUsersWhereRead_whenGettingGithubUsers_thenReturnAllUsers() throws Exception {
+
+        List<String> actualGithubUsers = sheetsFloatGithubUserConverter.getGithubUsers();
+
+        assertEquals(Arrays.asList("github meirinho", "sparrow"), actualGithubUsers);
+    }
+
+    @Test
+    public void givenUsersWereReadAndHaveNoContent_whenGettingGithubUsers_thenReturnAllUsers() throws Exception {
+        given(mockSheetsServiceClient.getEntries()).willReturn(Observable.from(Collections.emptyList()));
+
+        List<String> actualGithubUsers = sheetsFloatGithubUserConverter.getGithubUsers();
+
+        assertEquals(Collections.emptyList(), actualGithubUsers);
+    }
+
+    private List<Entry> givenEntries() {
+        Entry anEntry = new Entry("Float Pirata", "github meirinho");
+        Entry anotherEntry = new Entry("Jack Pirata", "sparrow");
+        return Arrays.asList(anEntry, anotherEntry);
+    }
+
+}

--- a/float/src/test/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverterTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverterTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import rx.Observable;
-import rx.schedulers.Schedulers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -29,7 +28,7 @@ public class SheetsFloatGithubUserConverterTest {
     public void setUp() throws Exception {
         initMocks(this);
         given(mockSheetsServiceClient.getEntries()).willReturn(Observable.from(givenEntries()));
-        sheetsFloatGithubUserConverter = new SheetsFloatGithubUserConverter(mockSheetsServiceClient, Schedulers.immediate());
+        sheetsFloatGithubUserConverter = new SheetsFloatGithubUserConverter(mockSheetsServiceClient);
     }
 
     @Test

--- a/float/src/test/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverterTest.java
+++ b/float/src/test/java/com/novoda/floatschedule/convert/SheetsFloatGithubUserConverterTest.java
@@ -41,7 +41,7 @@ public class SheetsFloatGithubUserConverterTest {
     }
 
     @Test(expected = NoMatchFoundException.class)
-    public void givenThereIsNoMatch_whenGettingTheFloatUsernameForAGithubUsername_thenThrowsException() throws Exception {
+    public void givenUsersWereReadButThereIsNoMatch_whenGettingTheFloatUsernameForAGithubUsername_thenThrowsException() throws Exception {
 
         sheetsFloatGithubUserConverter.getFloatUser("sebastião");
 

--- a/reports-stats/src/main/java/com/novoda/github/reports/stats/handler/ProjectCommandHandler.java
+++ b/reports-stats/src/main/java/com/novoda/github/reports/stats/handler/ProjectCommandHandler.java
@@ -1,12 +1,12 @@
 package com.novoda.github.reports.stats.handler;
 
+import com.novoda.floatschedule.convert.FailedToLoadMappingsException;
 import com.novoda.floatschedule.convert.FloatGithubProjectConverter;
 import com.novoda.github.reports.data.DataLayerException;
 import com.novoda.github.reports.data.RepoDataLayer;
 import com.novoda.github.reports.data.model.ProjectRepoStats;
 import com.novoda.github.reports.stats.command.ProjectOptions;
 
-import java.io.IOException;
 import java.util.List;
 
 public class ProjectCommandHandler implements CommandHandler<ProjectRepoStats, ProjectOptions> {
@@ -25,7 +25,7 @@ public class ProjectCommandHandler implements CommandHandler<ProjectRepoStats, P
             List<String> repositories = floatGithubProjectConverter.getRepositories(project);
             ProjectRepoStats stats = dataLayer.getStats(repositories, options.getFrom(), options.getTo());
             return new ProjectRepoStats(project, stats.getEventStats(), stats.getNumberOfParticipatingUsers());
-        } catch (DataLayerException | IOException e) {
+        } catch (DataLayerException | FailedToLoadMappingsException e) {
             e.printStackTrace();
         }
         return null;

--- a/reports-stats/src/test/java/com/novoda/github/reports/stats/handler/ProjectCommandHandlerTest.java
+++ b/reports-stats/src/test/java/com/novoda/github/reports/stats/handler/ProjectCommandHandlerTest.java
@@ -1,22 +1,23 @@
 package com.novoda.github.reports.stats.handler;
 
+import com.novoda.floatschedule.convert.FailedToLoadMappingsException;
 import com.novoda.floatschedule.convert.FloatGithubProjectConverter;
 import com.novoda.github.reports.data.DataLayerException;
 import com.novoda.github.reports.data.RepoDataLayer;
 import com.novoda.github.reports.data.model.EventStats;
 import com.novoda.github.reports.data.model.ProjectRepoStats;
 import com.novoda.github.reports.stats.command.ProjectOptions;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 
-import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
@@ -66,7 +67,7 @@ public class ProjectCommandHandlerTest {
     }
 
     @Test
-    public void whenHandlingAProjectCommand_thenWeGetStatsForTheArgsPassedIn() throws DataLayerException, IOException {
+    public void whenHandlingAProjectCommand_thenWeGetStatsForTheArgsPassedIn() throws DataLayerException, FailedToLoadMappingsException {
         given(mockConverter.getRepositories(ANY_PROJECT)).willReturn(ANY_PROJECT_REPO_LIST);
         given(mockDataLayer.getStats(ANY_PROJECT_REPO_LIST, ANY_FROM_DATE, ANY_TO_DATE)).willReturn(ANY_PROJECT_STATS);
 
@@ -76,7 +77,7 @@ public class ProjectCommandHandlerTest {
     }
 
     @Test
-    public void whenHandlingAProjectCommand_theReturnedStatsAreMutatedByTheHandler() throws DataLayerException, IOException {
+    public void whenHandlingAProjectCommand_theReturnedStatsAreMutatedByTheHandler() throws DataLayerException, FailedToLoadMappingsException {
         given(mockConverter.getRepositories(ANY_PROJECT)).willReturn(ANY_PROJECT_REPO_LIST);
         given(mockDataLayer.getStats(ANY_PROJECT_REPO_LIST, ANY_FROM_DATE, ANY_TO_DATE)).willReturn(ANY_PROJECT_STATS);
 


### PR DESCRIPTION
#### Problem

As we now have in place what we need to hit a given sheets document and get its contents, we should now move to using it appropriately, i.e., read user mappings when needed.

#### Solution

As we're aiming to provide an alternate solution (there's one already in place), it was first wrapped in an interface so as to guarantee a common API and non-breaking changes for its clients. This is the `GithubUserConverter` interface.

Some extraction of predicates (filters) and suppliers (exceptions) took place in order do avoid duplication.

So we're now providing a `SheetsFloatGithubUserConverter` which will hit the document when its contents are empty, synchronously by default, given that when a client asks for a name we're assuming it needs it then.

##### Test(s) added

Yes.
