### PR TITLE
Fix print username

### DIFF
--- a/github-hooks-web-service/src/main/java/com/novoda/github/reports/web/hooks/model/GithubWebhookEvent.java
+++ b/github-hooks-web-service/src/main/java/com/novoda/github/reports/web/hooks/model/GithubWebhookEvent.java
@@ -44,13 +44,13 @@ public abstract class GithubWebhookEvent {
 
     @Override
     public String toString() {
-        String username = sender() == null ? "[NO SENDER]" : sender().toString();
+        String username = sender() == null ? "[NO SENDER]" : sender().getUsername();
         String issueNumber = issue() == null ? "[NO ISSUE]" : issue().toString();
         String prId = pullRequest() == null ? "[NO PR]" : pullRequest().toString();
         String repoName = repository() == null ? "[NO REPO]" : repository().toString();
         String comment = comment() == null ? "[NO COMMENT]" : comment().toString();
         return String.format(
-                "(%s){\naction=%s,\nuser=%s,\nissue=%s,\npr=%s,\nrepo=%s,\ncomment=%s\n}",
+                "(%s){\n action=%s,\n user=%s,\n issue=%s,\n pr=%s,\n repo=%s,\n comment=%s\n}",
                 getClass().getSimpleName(),
                 action(),
                 username,

--- a/github/src/main/java/com/novoda/github/reports/service/network/GithubApiService.java
+++ b/github/src/main/java/com/novoda/github/reports/service/network/GithubApiService.java
@@ -6,13 +6,14 @@ import com.novoda.github.reports.service.issue.GithubIssue;
 import com.novoda.github.reports.service.issue.GithubReaction;
 import com.novoda.github.reports.service.repository.GithubRepository;
 import com.novoda.github.reports.service.timeline.TimelineEvent;
+
+import java.util.List;
+
 import retrofit2.Response;
 import retrofit2.http.GET;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 import rx.Observable;
-
-import java.util.List;
 
 public interface GithubApiService {
 
@@ -71,6 +72,7 @@ public interface GithubApiService {
             @Query("per_page") int perPageCount
     );
 
+    @Deprecated
     @GET("/repos/{org}/{repo}/issues/{issue_number}/timeline")
     Observable<Response<List<TimelineEvent>>> getTimelineFor(
             @Path("org") String organisation,


### PR DESCRIPTION
#### Problem

#59 wrongfully replaced `sender().getUsername()` with `sender().toString()`. As `sender()` returns a `GithubUser` which does not implement `toString()`, we're now failing to log the username properly.

#### Solution

Use `getUsername()` instead of `toString()`.

##### Test(s) added

No. Plain logging.
