### PR TITLE
Handle missing X-RateLimit-Remaining header

### DIFF
--- a/github/build.gradle
+++ b/github/build.gradle
@@ -21,4 +21,5 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.0.71-beta'
+    testCompile 'org.assertj:assertj-core:3.5.2'
 }

--- a/github/src/main/java/com/novoda/github/reports/service/network/RateLimitCountInterceptor.java
+++ b/github/src/main/java/com/novoda/github/reports/service/network/RateLimitCountInterceptor.java
@@ -2,6 +2,7 @@ package com.novoda.github.reports.service.network;
 
 import java.io.IOException;
 
+import com.novoda.github.reports.util.StringHelper;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -27,7 +28,7 @@ class RateLimitCountInterceptor implements Interceptor {
         Response response = chain.proceed(request);
 
         String countAsString = response.headers().get(REMAINING_RATE_LIMIT_HEADER);
-        int remainingCount = Integer.valueOf(countAsString);
+        int remainingCount = StringHelper.isNullOrEmpty(countAsString) ? 0 : Integer.valueOf(countAsString);
         rateLimitRemainingCounter.set(remainingCount);
 
         return response;

--- a/github/src/test/java/com/novoda/github/reports/service/network/RateLimitCountInterceptorTest.java
+++ b/github/src/test/java/com/novoda/github/reports/service/network/RateLimitCountInterceptorTest.java
@@ -3,13 +3,15 @@ package com.novoda.github.reports.service.network;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.stubbing.Answer;
 
 import okhttp3.Interceptor;
 import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -21,6 +23,7 @@ public class RateLimitCountInterceptorTest {
     private static final Protocol ANY_PROTOCOL = Protocol.HTTP_1_1;
     private static final int ANY_STATUS_CODE = 200;
     private static final String ANY_COUNT = "5";
+    private static final String EMPTY_COUNT = "";
     private static final Request ANY_REQUEST = new Request.Builder().url(ANY_URL).build();
 
     @Mock
@@ -38,24 +41,62 @@ public class RateLimitCountInterceptorTest {
         interceptor = new RateLimitCountInterceptor(mockCounter);
 
         when(mockChain.request()).thenReturn(ANY_REQUEST);
-
-        when(mockChain.proceed(any(Request.class))).thenAnswer(
-                (Answer<Response>) invocation ->
-                        new Response.Builder()
-                                .protocol(ANY_PROTOCOL)
-                                .code(ANY_STATUS_CODE)
-                                .request(ANY_REQUEST)
-                                .header("X-RateLimit-Remaining", ANY_COUNT)
-                                .build()
-        );
     }
 
     @Test
-    public void whenTheRequestIsIntercepted_thenWeGetTheRemainingRateLimit() throws Exception {
+    public void givenMissingRateLimitRemaining_whenTheRequestIsIntercepted_thenCounterIsSetToZero() throws Exception {
+        givenChainResponseWithoutRateLimitRemaining();
+
+        interceptor.intercept(mockChain);
+
+        verify(mockCounter).set(0);
+    }
+
+    @Test
+    public void givenEmptyRateLimitRemaining_whenTheRequestIsIntercepted_thenCounterIsSetToZero() throws Exception {
+        givenChainResponseWithRateLimitRemaining(EMPTY_COUNT);
+
+        interceptor.intercept(mockChain);
+
+        verify(mockCounter).set(0);
+    }
+
+    @Test
+    public void givenARateLimitRemaining_whenTheRequestIsIntercepted_thenWeGetTheRemainingRateLimit() throws Exception {
+        givenChainResponseWithRateLimitRemaining(ANY_COUNT);
 
         Response response = interceptor.intercept(mockChain);
-        int count = Integer.parseInt(response.header("X-RateLimit-Remaining"));
 
-        verify(mockCounter).set(count);
+        assertThat(response.header("X-RateLimit-Remaining")).isEqualTo(ANY_COUNT);
+    }
+
+    @Test
+    public void givenARateLimitRemaining_whenTheRequestIsIntercepted_thenTheCounterIsSet() throws Exception {
+        givenChainResponseWithRateLimitRemaining(ANY_COUNT);
+
+        interceptor.intercept(mockChain);
+
+        verify(mockCounter).set(Integer.parseInt(ANY_COUNT));
+    }
+
+    private void givenChainResponseWithRateLimitRemaining(String count) throws IOException {
+        when(mockChain.proceed(any(Request.class))).thenAnswer(
+                invocation -> new Response.Builder()
+                        .protocol(ANY_PROTOCOL)
+                        .code(ANY_STATUS_CODE)
+                        .request(ANY_REQUEST)
+                        .header("X-RateLimit-Remaining", count)
+                        .build()
+        );
+    }
+
+    private void givenChainResponseWithoutRateLimitRemaining() throws IOException {
+        when(mockChain.proceed(any(Request.class))).thenAnswer(
+                invocation -> new Response.Builder()
+                        .protocol(ANY_PROTOCOL)
+                        .code(ANY_STATUS_CODE)
+                        .request(ANY_REQUEST)
+                        .build()
+        );
     }
 }

--- a/github/src/test/java/com/novoda/github/reports/service/network/RateLimitCountInterceptorTest.java
+++ b/github/src/test/java/com/novoda/github/reports/service/network/RateLimitCountInterceptorTest.java
@@ -54,7 +54,7 @@ public class RateLimitCountInterceptorTest {
 
     @Test
     public void givenEmptyRateLimitRemaining_whenTheRequestIsIntercepted_thenCounterIsSetToZero() throws Exception {
-        givenChainResponseWithRateLimitRemaining(EMPTY_COUNT);
+        givenChainResponseWithRateLimitRemainingOf(EMPTY_COUNT);
 
         interceptor.intercept(mockChain);
 
@@ -63,7 +63,7 @@ public class RateLimitCountInterceptorTest {
 
     @Test
     public void givenARateLimitRemaining_whenTheRequestIsIntercepted_thenWeGetTheRemainingRateLimit() throws Exception {
-        givenChainResponseWithRateLimitRemaining(ANY_COUNT);
+        givenChainResponseWithRateLimitRemainingOf(ANY_COUNT);
 
         Response response = interceptor.intercept(mockChain);
 
@@ -72,14 +72,14 @@ public class RateLimitCountInterceptorTest {
 
     @Test
     public void givenARateLimitRemaining_whenTheRequestIsIntercepted_thenTheCounterIsSet() throws Exception {
-        givenChainResponseWithRateLimitRemaining(ANY_COUNT);
+        givenChainResponseWithRateLimitRemainingOf(ANY_COUNT);
 
         interceptor.intercept(mockChain);
 
         verify(mockCounter).set(Integer.parseInt(ANY_COUNT));
     }
 
-    private void givenChainResponseWithRateLimitRemaining(String count) throws IOException {
+    private void givenChainResponseWithRateLimitRemainingOf(String count) throws IOException {
         when(mockChain.proceed(any(Request.class))).thenAnswer(
                 invocation -> new Response.Builder()
                         .protocol(ANY_PROTOCOL)


### PR DESCRIPTION
#### Problem

During the GitHub outage from this morning, some API calls were missing the `X-RateLimit-Remaining` header, crashing our lambda due to an NPE in `RateLimitCountInterceptor`.

#### Solution

In `RateLimitCountInterceptor`, if the header is missing, use `0` for the `RateLimitRemainingCounter`. This way, the execution will be postponed until the current rate limit window resets.

##### Test(s) added

Yes, tested the interceptor's behaviour on missing or empty rate limit header values.


